### PR TITLE
Add --simple-binary

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ OPTIONS:
     -g, --script-group-type <script-group-type>    Script group type [possible values: lock, type]
     -h, --script-hash <script-hash>                Script hash
         --script-version <script-version>          Script version [default: 1]
+        --simple-binary <simple-binary>            Run a simple program that without any system calls
         --skip-end <skip-end>                      End address to skip printing debug info
         --skip-start <skip-start>                  Start address to skip printing debug info
     -t, --tx-file <tx-file>                        Filename containing JSON formatted transaction dump


### PR DESCRIPTION
#17 

```sh
# Run a simple program
$ ./ckb-debugger --simple-binary /src/ckb-vm-pprof/res/abc
Run result: 0
Total cycles consumed: 1459

# Run a simple program and profile it
$ ./ckb-debugger --simple-binary /src/ckb-vm-pprof/res/abc --pprof /tmp/flamegraph.txt
$ cat /tmp/flamegraph.txt | inferno-flamegraph > /tmp/flamegraph.svg

# Run a simple error program
$ ./ckb-debugger --simple-binary /src/ckb-vm-pprof/res/outofmemory
Backtrace:
??:??
/code/outofmemory.c:main
/code/outofmemory.c:c
/code/outofmemory.c:b
/code/outofmemory.c:a
/code/outofmemory.c:5
Machine returned error code: OutOfBound
```