### PR TITLE
Human readable cycles

### DIFF
--- a/bins/src/main.rs
+++ b/bins/src/main.rs
@@ -29,6 +29,8 @@ use serde_plain::from_str as from_plain_str;
 use std::collections::HashSet;
 use std::fs::{read, read_to_string};
 use std::net::TcpListener;
+mod misc;
+use misc::HumanReadableCycles;
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     drop(env_logger::init());
@@ -347,11 +349,11 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         match result {
             Ok(data) => {
                 println!("Run result: {:?}", data);
-                println!("Total cycles consumed: {}", machine.machine.cycles());
+                println!("Total cycles consumed: {}", HumanReadableCycles(machine.machine.cycles()));
                 println!(
                     "Transfer cycles: {}, running cycles: {}",
-                    transferred_cycles,
-                    machine.machine.cycles() - transferred_cycles
+                    HumanReadableCycles(transferred_cycles),
+                    HumanReadableCycles(machine.machine.cycles() - transferred_cycles)
                 );
                 if let Some(fp) = matches_pprof {
                     let mut output = std::fs::File::create(&fp)?;
@@ -376,11 +378,11 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         let transferred_cycles = transferred_byte_cycles(bytes);
         machine.add_cycles(transferred_cycles)?;
         println!("Run result: {:?}", machine.run());
-        println!("Total cycles consumed: {}", machine.cycles());
+        println!("Total cycles consumed: {}", HumanReadableCycles(machine.cycles()));
         println!(
             "Transfer cycles: {}, running cycles: {}",
-            transferred_cycles,
-            machine.cycles() - transferred_cycles
+            HumanReadableCycles(transferred_cycles),
+            HumanReadableCycles(machine.cycles() - transferred_cycles)
         );
         return Ok(());
     }

--- a/bins/src/misc.rs
+++ b/bins/src/misc.rs
@@ -5,9 +5,9 @@ pub struct HumanReadableCycles(pub u64);
 impl fmt::Display for HumanReadableCycles {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{}", self.0)?;
-        if self.0 > 1024 * 1024 {
+        if self.0 >= 1024 * 1024 {
             write!(f, "({:.1}M)", self.0 as f64 / 1024. / 1024.)?;
-        } else if self.0 > 1024 {
+        } else if self.0 >= 1024 {
             write!(f, "({:.1}K)", self.0 as f64 / 1024.)?;
         } else {
 

--- a/bins/src/misc.rs
+++ b/bins/src/misc.rs
@@ -1,0 +1,17 @@
+use std::fmt;
+
+pub struct HumanReadableCycles(pub u64);
+
+impl fmt::Display for HumanReadableCycles {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.0)?;
+        if self.0 > 1024 * 1024 {
+            write!(f, "({:.1}M)", self.0 as f64 / 1024. / 1024.)?;
+        } else if self.0 > 1024 {
+            write!(f, "({:.1}K)", self.0 as f64 / 1024.)?;
+        } else {
+
+        }
+        Ok(())
+    }
+}


### PR DESCRIPTION
Optimize cycles output format.


Before

```
 ./target/debug/ckb-debugger --bin ~/src/ckb-vm-pprof/res/fib
Run result: 0
Total cycles consumed: 2824
Transfer cycles: 728, running cycles: 2096
```

After

```
 ./target/debug/ckb-debugger --bin ~/src/ckb-vm-pprof/res/fib
Run result: 0
Total cycles consumed: 2824(2.8K)
Transfer cycles: 728, running cycles: 2096(2.0K)
```