### PR TITLE
Add a simple DSL in dummy_tx.json

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -200,6 +200,7 @@ name = "ckb-debugger"
 version = "0.108.0"
 dependencies = [
  "ckb-debugger-api",
+ "ckb-hash",
  "ckb-mock-tx-types",
  "ckb-script",
  "ckb-types",
@@ -210,10 +211,12 @@ dependencies = [
  "env_logger",
  "faster-hex 0.4.1",
  "gdb-remote-protocol",
+ "hex",
  "lazy_static",
  "libc",
  "log 0.4.17",
  "rand 0.8.5",
+ "regex 1.7.1",
  "serde_json",
  "serde_plain",
 ]
@@ -789,6 +792,12 @@ name = "hermit-abi"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fed44880c466736ef9a5c5b5facefb5ed0785676d0c02d612db14e54f0d84286"
+
+[[package]]
+name = "hex"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "includedir"

--- a/ckb-debugger/Cargo.toml
+++ b/ckb-debugger/Cargo.toml
@@ -13,6 +13,7 @@ stdio = ["ckb-vm-debug-utils/stdio"]
 [dependencies]
 clap = "2.33.0"
 ckb-debugger-api = { path = "../ckb-debugger-api" }
+ckb-hash = "=0.108.0"
 ckb-mock-tx-types = { path = "../ckb-mock-tx-types" }
 ckb-script = { version="=0.108.0", default-features = false }
 ckb-types = "=0.108.0"
@@ -22,9 +23,11 @@ ckb-vm-pprof = { path = "../ckb-vm-pprof" }
 env_logger = "0.4.3"
 faster-hex = "0.4.0"
 gdb-remote-protocol = { git = "https://github.com/luser/rust-gdb-remote-protocol", rev = "565ab0c" }
+hex = "0.4"
 lazy_static = "1.4.0"
 libc = "0.2.132"
 log = "0.4.0"
 rand = "0.8.5"
+regex = "1"
 serde_json = "1.0"
 serde_plain = "1.0"


### PR DESCRIPTION
Allowed write `{{ data path/to/script }}` and `{{ hash path/to/script }}` in `tx.json`.

Example: https://github.com/mohanson/ckb-standalone-debugger/blob/syscall_spawn/ckb-debugger/examples/spawn.json

```json
{
  "mock_info": {
    "inputs": [
      {
        "input": {
          "since": "0x0",
          "previous_output": {
            "tx_hash": "0x0000000000000000000000000000000000000000000000000000000000000002",
            "index": "0x0"
          }
        },
        "output": {
          "capacity": "0x10000000",
          "lock": {
            "code_hash": "{{ hash spawn_caller_strcat }}",
            "hash_type": "data1",
            "args": "0x"
          },
          "type": null
        },
        "data": "0x",
        "header": null
      }
    ],
    "cell_deps": [
      {
        "cell_dep": {
          "out_point": {
            "tx_hash": "0x0000000000000000000000000000000000000000000000000000000000000001",
            "index": "0x0"
          },
          "dep_type": "code"
        },
        "output": {
          "capacity": "0x10000000",
          "lock": {
            "code_hash": "0x0000000000000000000000000000000000000000000000000000000000000000",
            "hash_type": "data1",
            "args": "0x"
          },
          "type": null
        },
        "data": "{{ data spawn_caller_strcat }}",
        "header": null
      },
      {
        "cell_dep": {
          "out_point": {
            "tx_hash": "0x0000000000000000000000000000000000000000000000000000000000000001",
            "index": "0x1"
          },
          "dep_type": "code"
        },
        "output": {
          "capacity": "0x10000000",
          "lock": {
            "code_hash": "0x0000000000000000000000000000000000000000000000000000000000000000",
            "hash_type": "data1",
            "args": "0x"
          },
          "type": null
        },
        "data": "{{ data spawn_callee_strcat }}",
        "header": null
      }
    ],
    "header_deps": []
  },
  "tx": {
    "version": "0x0",
    "cell_deps": [
      {
        "out_point": {
          "tx_hash": "0x0000000000000000000000000000000000000000000000000000000000000001",
          "index": "0x0"
        },
        "dep_type": "code"
      },
      {
        "out_point": {
          "tx_hash": "0x0000000000000000000000000000000000000000000000000000000000000001",
          "index": "0x1"
        },
        "dep_type": "code"
      }
    ],
    "header_deps": [],
    "inputs": [
      {
        "since": "0x0",
        "previous_output": {
          "tx_hash": "0x0000000000000000000000000000000000000000000000000000000000000002",
          "index": "0x0"
        }
      }
    ],
    "outputs": [
      {
        "capacity": "0x0",
        "lock": {
          "code_hash": "0x0000000000000000000000000000000000000000000000000000000000000000",
          "hash_type": "data1",
          "args": "0x"
        },
        "type": {
          "code_hash": "0x0000000000000000000000000000000000000000000000000000000000000000",
          "hash_type": "data1",
          "args": "0x"
        }
      }
    ],
    "outputs_data": [
      "0x"
    ],
    "witnesses": [
      "0x"
    ]
  }
}
```