### PR TITLE
ckb-debugger-api, print error when replace_data failed

### DIFF
--- a/ckb-debugger-api/src/embed.rs
+++ b/ckb-debugger-api/src/embed.rs
@@ -34,7 +34,11 @@ impl Embed {
                 } else {
                     Path::new(cap1).to_path_buf()
                 };
-                let data = std::fs::read(path).unwrap();
+                let data = std::fs::read(&path);
+                if data.is_err() {
+                    panic!("Read {:?} failed : {:?}", path, data);
+                }
+                let data = data.unwrap();
                 hex::encode(data)
             })
             .to_string();


### PR DESCRIPTION
When the data tag path configuration of templates is wrong, more detailed information can be printed.