### PR TITLE
Use more friendly format to print instructions

### DIFF
--- a/ckb-debugger/src/decode.rs
+++ b/ckb-debugger/src/decode.rs
@@ -10,24 +10,31 @@ pub fn decode_instruction(data: &str) -> Result<(), Box<dyn std::error::Error>> 
 
     let (ins, isa) = if let Some(i) = i::factory::<u64>(instruction, VERSION2) {
         let tagged_instruction: tagged::TaggedInstruction = tagged::TaggedInstruction::try_from(i).unwrap();
-        (tagged_instruction.to_string(), "Integer Instruction")
+        (tagged_instruction.to_string(), "I")
     } else if let Some(i) = m::factory::<u64>(instruction, VERSION2) {
         let tagged_instruction = tagged::TaggedInstruction::try_from(i).unwrap();
-        (tagged_instruction.to_string(), "M extension")
+        (tagged_instruction.to_string(), "M")
     } else if let Some(i) = a::factory::<u64>(instruction, VERSION2) {
         let tagged_instruction = tagged::TaggedInstruction::try_from(i).unwrap();
-        (tagged_instruction.to_string(), "A extension")
+        (tagged_instruction.to_string(), "A")
     } else if let Some(i) = b::factory::<u64>(instruction, VERSION2) {
         let tagged_instruction = tagged::TaggedInstruction::try_from(i).unwrap();
-        (tagged_instruction.to_string(), "B extension")
+        (tagged_instruction.to_string(), "B")
     } else if let Some(i) = rvc::factory::<u64>(instruction, VERSION2) {
         let tagged_instruction = tagged::TaggedInstruction::try_from(i).unwrap();
-        (tagged_instruction.to_string(), "RVC")
+        (tagged_instruction.to_string(), "C")
     } else {
         panic!("unknow instruction")
     };
 
-    println!("instruction: {}\nIt is in RISC-V {}.", ins, isa);
+    println!("       Assembly = {}", ins);
+    println!("         Binary = {:032b}", instruction);
+    if isa == "C" {
+        println!("    Hexadecimal = {:04x}", instruction);
+    } else {
+        println!("    Hexadecimal = {:08x}", instruction);
+    }
+    println!("Instruction set = {}", isa);
 
     Ok(())
 }

--- a/ckb-debugger/src/decode.rs
+++ b/ckb-debugger/src/decode.rs
@@ -24,14 +24,15 @@ pub fn decode_instruction(data: &str) -> Result<(), Box<dyn std::error::Error>> 
         let tagged_instruction = tagged::TaggedInstruction::try_from(i).unwrap();
         (tagged_instruction.to_string(), "C")
     } else {
-        panic!("unknow instruction")
+        ("?".to_string(), "?")
     };
 
     println!("       Assembly = {}", ins);
-    println!("         Binary = {:032b}", instruction);
     if isa == "C" {
+        println!("         Binary = {:016b}", instruction);
         println!("    Hexadecimal = {:04x}", instruction);
     } else {
+        println!("         Binary = {:032b}", instruction);
         println!("    Hexadecimal = {:08x}", instruction);
     }
     println!("Instruction set = {}", isa);


### PR DESCRIPTION

```sh
$ ckb-debugger --decode 0xeb5352f

       Assembly = amoswap_d a0,a0,a1
         Binary = 00001110101101010011010100101111
    Hexadecimal = 0eb5352f
Instruction set = A
```