### PR TITLE
Make get_script_hash_by_index a standalone function

### DIFF
--- a/ckb-debugger-api/src/lib.rs
+++ b/ckb-debugger-api/src/lib.rs
@@ -175,3 +175,36 @@ pub fn check(tx: &ReprMockTransaction) -> Result<(), String> {
     }
     Ok(())
 }
+
+// Get script hash by give group type, cell type and cell index.
+// Note cell_type should be a string, in the range ["input", "output"].
+pub fn get_script_hash_by_index(
+    mock_tx: &MockTransaction,
+    script_group_type: &ScriptGroupType,
+    cell_type: &str,
+    cell_index: usize,
+) -> Byte32 {
+    match (&script_group_type, cell_type) {
+        (ScriptGroupType::Lock, "input") => mock_tx.mock_info.inputs[cell_index].output.calc_lock_hash(),
+        (ScriptGroupType::Type, "input") => mock_tx.mock_info.inputs[cell_index]
+            .output
+            .type_()
+            .to_opt()
+            .expect("cell should have type script")
+            .calc_script_hash(),
+        (ScriptGroupType::Type, "output") => mock_tx
+            .tx
+            .raw()
+            .outputs()
+            .get(cell_index)
+            .expect("index out of bound")
+            .type_()
+            .to_opt()
+            .expect("cell should have type script")
+            .calc_script_hash(),
+        _ => panic!(
+            "Invalid specified script: {:?} {} {}",
+            script_group_type, cell_type, cell_index
+        ),
+    }
+}

--- a/ckb-debugger/src/main.rs
+++ b/ckb-debugger/src/main.rs
@@ -1,5 +1,5 @@
 use ckb_chain_spec::consensus::ConsensusBuilder;
-use ckb_debugger_api::check;
+use ckb_debugger_api::{check, get_script_hash_by_index};
 use ckb_debugger_api::embed::Embed;
 use ckb_debugger_api::DummyResourceLoader;
 use ckb_mock_tx_types::{MockTransaction, ReprMockTransaction, Resource};
@@ -265,29 +265,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         }
         let cell_type = cell_type.unwrap();
         let cell_index: usize = cell_index.unwrap().parse()?;
-        match (&verifier_script_group_type, cell_type) {
-            (ScriptGroupType::Lock, "input") => verifier_mock_tx.mock_info.inputs[cell_index].output.calc_lock_hash(),
-            (ScriptGroupType::Type, "input") => verifier_mock_tx.mock_info.inputs[cell_index]
-                .output
-                .type_()
-                .to_opt()
-                .expect("cell should have type script")
-                .calc_script_hash(),
-            (ScriptGroupType::Type, "output") => verifier_mock_tx
-                .tx
-                .raw()
-                .outputs()
-                .get(cell_index)
-                .expect("index out of bound")
-                .type_()
-                .to_opt()
-                .expect("cell should have type script")
-                .calc_script_hash(),
-            _ => panic!(
-                "Invalid specified script: {:?} {} {}",
-                verifier_script_group_type, cell_type, cell_index
-            ),
-        }
+        get_script_hash_by_index(&verifier_mock_tx, &verifier_script_group_type, cell_type, cell_index)
     };
     let verifier_script_version = match matches_script_version {
         "0" => ScriptVersion::V0,


### PR DESCRIPTION
The `run()` method in `ckb-debugger-api` accepts script_hash, so it is useful to provide a method to quickly calculate script_hash from index.

https://github.com/nervosnetwork/ckb-standalone-debugger/blob/fcd4e51a4676000a50d4b3dd0d61f095237e26f7/ckb-debugger-api/src/lib.rs#L36

