### PR TITLE
Make gdbstub a CLI argument instead of a feature.

### DIFF
--- a/ckb-debugger/Cargo.toml
+++ b/ckb-debugger/Cargo.toml
@@ -10,7 +10,6 @@ edition = "2021"
 default = ["probes"]
 stdio = ["ckb-vm-debug-utils/stdio"]
 probes = ["probe", "ckb-script/flatmemory"]
-gdbstub_impl = ["gdbstub", "gdbstub_arch"]
 
 [dependencies]
 clap = "2.33.0"
@@ -26,8 +25,8 @@ ckb-vm-pprof = { path = "../ckb-vm-pprof" }
 env_logger = "0.4.3"
 faster-hex = "0.4.0"
 gdb-remote-protocol = { git = "https://github.com/luser/rust-gdb-remote-protocol", rev = "565ab0c" }
-gdbstub = { version = "0.6.6", optional = true }
-gdbstub_arch = { version = "0.2.4", optional = true }
+gdbstub = "0.6.6"
+gdbstub_arch = "0.2.4"
 hex = "0.4"
 lazy_static = "1.4.0"
 libc = "0.2.132"


### PR DESCRIPTION
Previously, a compile-time feature is used to decide whether to use gdb-remote-protocol or gdbstub as the underlying engine for gdb remote serial protocol. However, this means one typically needs to manually compile the debugger project if gdbstub shall be used. This change makes gdbstub a new CLI mode, so one can use a single pre-built binary to try out different gdb engines.