### PR TITLE
Remove faster-hex

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -309,7 +309,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df80db694e42b64a5774ae551daff3c8310cd99bb528643dbe0dd409abb298e7"
 dependencies = [
  "ckb-fixed-hash",
- "faster-hex 0.6.1",
+ "faster-hex",
  "lazy_static",
  "rand 0.7.3",
  "secp256k1",
@@ -343,7 +343,6 @@ dependencies = [
  "ckb-vm-pprof",
  "clap 2.34.0",
  "env_logger 0.4.3",
- "faster-hex 0.4.1",
  "gdbstub",
  "gdbstub_arch",
  "hex",
@@ -368,7 +367,6 @@ dependencies = [
  "ckb-script",
  "ckb-types",
  "ckb-vm",
- "faster-hex 0.4.1",
  "hex",
  "js-sys",
  "regex 1.9.5",
@@ -406,7 +404,7 @@ version = "0.111.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bdd1727a6ecd4d0bcab604cb1ef707fe92e939fa6e9a438f9f25bf05208cb080"
 dependencies = [
- "faster-hex 0.6.1",
+ "faster-hex",
  "serde",
  "thiserror",
 ]
@@ -474,7 +472,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d789a71538da07871c11aecbd28d6c632bb426bdfeed5fc2fa1b455e31152468"
 dependencies = [
  "ckb-types",
- "faster-hex 0.6.1",
+ "faster-hex",
  "serde",
  "serde_json",
 ]
@@ -580,7 +578,7 @@ dependencies = [
  "ckb-traits",
  "ckb-types",
  "ckb-vm",
- "faster-hex 0.6.1",
+ "faster-hex",
  "serde",
 ]
 
@@ -591,7 +589,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fa5c59063142de7a68cfad4449c6b3863563856219a2925dfb8c5f019ec2aa47"
 dependencies = [
  "blake2b-rs",
- "faster-hex 0.6.1",
+ "faster-hex",
  "includedir",
  "includedir_codegen",
  "phf",
@@ -944,12 +942,6 @@ checksum = "4443176a9f2c162692bd3d352d745ef9413eec5782a80d8fd6f8a1ac692a07f7"
 
 [[package]]
 name = "faster-hex"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "348138dd23e03bb0018caef99647fb1a5befec5ff4b501991de88f09854d4c28"
-
-[[package]]
-name = "faster-hex"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "51e2ce894d53b295cf97b05685aa077950ff3e8541af83217fc720a6437169f8"
@@ -1278,7 +1270,7 @@ checksum = "d4fd9767ab5e5f2ea40f71ff4c8bdb633c50509052e093c2fdd0e390a749dfa3"
 dependencies = [
  "bytes",
  "cfg-if",
- "faster-hex 0.6.1",
+ "faster-hex",
 ]
 
 [[package]]

--- a/ckb-debugger-api/Cargo.toml
+++ b/ckb-debugger-api/Cargo.toml
@@ -17,7 +17,6 @@ ckb-mock-tx-types = { path = "../ckb-mock-tx-types", version="0.111.0" }
 ckb-script = { version = "=0.111.0", default-features = false }
 ckb-types = "=0.111.0"
 ckb-vm = "=0.24.6"
-faster-hex = "0.4.0"
 hex = "0.4"
 js-sys = "0.3.27"
 regex = "1"

--- a/ckb-debugger-api/src/lib.rs
+++ b/ckb-debugger-api/src/lib.rs
@@ -11,7 +11,6 @@ use ckb_types::{
     prelude::*,
     H256,
 };
-use faster_hex::hex_decode_fallback;
 use serde::{Deserialize, Serialize};
 use serde_json::{from_str as from_json_str, to_string as to_json_string};
 use serde_plain::from_str as from_plain_str;
@@ -98,9 +97,8 @@ fn internal_run_json(
     if hex_script_hash.len() != 66 || (!hex_script_hash.starts_with("0x")) {
         return Err("Invalid script hash format!".to_string());
     }
-    let mut b = [0u8; 32];
-    hex_decode_fallback(&hex_script_hash.as_bytes()[2..], &mut b[..]);
-    let script_hash = Byte32::new(b);
+    let b = hex::decode(&hex_script_hash.as_bytes()[2..]).map_err(|e| e.to_string())?;
+    let script_hash = Byte32::from_slice(b.as_slice()).map_err(|e| e.to_string())?;
     let max_cycle: Cycle = max_cycle.parse().map_err(|_| "Invalid max cycle!".to_string())?;
     run(&mock_tx, &script_group_type, &script_hash, max_cycle, debug_printer)
 }

--- a/ckb-debugger/Cargo.toml
+++ b/ckb-debugger/Cargo.toml
@@ -23,7 +23,6 @@ ckb-vm = { version = "=0.24.6" }
 ckb-vm-debug-utils = { path = "../ckb-vm-debug-utils", version="0.111.0" }
 ckb-vm-pprof = { path = "../ckb-vm-pprof", version="0.111.0" }
 env_logger = "0.4.3"
-faster-hex = "0.4.0"
 ckb-gdb-remote-protocol = { path = "../ckb-gdb-remote-protocol", version="0.111.0" }
 gdbstub = "0.6.6"
 gdbstub_arch = "0.2.4"

--- a/ckb-debugger/src/main.rs
+++ b/ckb-debugger/src/main.rs
@@ -11,6 +11,7 @@ use ckb_script::{
 use ckb_types::core::cell::resolve_transaction;
 use ckb_types::core::HeaderView;
 use ckb_types::packed::Byte32;
+use ckb_types::prelude::Entity;
 use ckb_vm::cost_model::estimate_cycles;
 use ckb_vm::decoder::build_decoder;
 use ckb_vm::error::Error;
@@ -27,7 +28,6 @@ use ckb_vm_debug_utils::ElfDumper;
 use ckb_vm_debug_utils::Stdio;
 use ckb_vm_pprof::{PProfMachine, Profile};
 use clap::{crate_version, App, Arg};
-use faster_hex::hex_decode_fallback;
 use serde_json::from_str as from_json_str;
 use serde_plain::from_str as from_plain_str;
 use std::fs::{read, read_to_string};
@@ -241,9 +241,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         if hex_script_hash.len() != 66 || (!hex_script_hash.starts_with("0x")) {
             panic!("Invalid script hash format!");
         }
-        let mut b = [0u8; 32];
-        hex_decode_fallback(&hex_script_hash.as_bytes()[2..], &mut b[..]);
-        Byte32::new(b)
+        let b = hex::decode(&hex_script_hash.as_bytes()[2..])?;
+        Byte32::from_slice(b.as_slice())?
     } else {
         let mut cell_type = matches_cell_type;
         let mut cell_index = matches_cell_index;

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,2 +1,2 @@
 max_width = 120
-chain_width = 119
+chain_width = 120


### PR DESCRIPTION
We have introduced `faster-hex` and `hex` with the same purpose, so delete one of them.