### PR TITLE
Made some optimizations to the code

### DIFF
--- a/ckb-debugger-api/src/embed.rs
+++ b/ckb-debugger-api/src/embed.rs
@@ -16,11 +16,7 @@ pub struct Embed {
 
 impl Embed {
     pub fn new(path: PathBuf, data: String) -> Self {
-        Self {
-            data,
-            path,
-            type_id_dict: HashMap::new(),
-        }
+        Self { data, path, type_id_dict: HashMap::new() }
     }
 
     pub fn replace_data(&mut self) -> &mut Self {

--- a/ckb-debugger-api/src/lib.rs
+++ b/ckb-debugger-api/src/lib.rs
@@ -72,14 +72,8 @@ struct JsonResult {
 impl From<Result<Cycle, String>> for JsonResult {
     fn from(result: Result<Cycle, String>) -> JsonResult {
         match result {
-            Ok(cycle) => JsonResult {
-                cycle: Some(cycle),
-                error: None,
-            },
-            Err(error) => JsonResult {
-                cycle: None,
-                error: Some(error),
-            },
+            Ok(cycle) => JsonResult { cycle: Some(cycle), error: None },
+            Err(error) => JsonResult { cycle: None, error: Some(error) },
         }
     }
 }
@@ -138,10 +132,7 @@ pub fn check(tx: &ReprMockTransaction) -> Result<(), String> {
             let outpoints: Vec<packed::OutPoint> = sub_outpoints.into_iter().collect::<Vec<_>>();
             let resolved_cell_deps: Vec<CellDep> = outpoints
                 .into_iter()
-                .map(|o| CellDep {
-                    out_point: o.into(),
-                    dep_type: DepType::Code,
-                })
+                .map(|o| CellDep { out_point: o.into(), dep_type: DepType::Code })
                 .collect::<Vec<_>>();
             cell_deps.extend(resolved_cell_deps);
         }
@@ -155,7 +146,11 @@ pub fn check(tx: &ReprMockTransaction) -> Result<(), String> {
     cell_deps.sort_by(compare);
 
     if mock_cell_deps.len() != cell_deps.len() {
-        return Err(format!("mock_cell_deps.len() != cell_deps.len(), {} != {}", mock_cell_deps.len(), cell_deps.len()));
+        return Err(format!(
+            "mock_cell_deps.len() != cell_deps.len(), {} != {}",
+            mock_cell_deps.len(),
+            cell_deps.len()
+        ));
     } else {
         for (a, b) in mock_cell_deps.into_iter().zip(cell_deps.into_iter()) {
             if a != b {
@@ -208,9 +203,6 @@ pub fn get_script_hash_by_index(
             .to_opt()
             .expect("cell should have type script")
             .calc_script_hash(),
-        _ => panic!(
-            "Invalid specified script: {:?} {} {}",
-            script_group_type, cell_type, cell_index
-        ),
+        _ => panic!("Invalid specified script: {:?} {} {}", script_group_type, cell_type, cell_index),
     }
 }

--- a/ckb-debugger-api/tests/test_json.rs
+++ b/ckb-debugger-api/tests/test_json.rs
@@ -4,23 +4,15 @@ use std::fs::read_to_string;
 #[test]
 pub fn test_sample_json() {
     let mock_tx = read_to_string("tests/programs/sample.json").unwrap();
-    let result = run_json(
-        &mock_tx,
-        "type",
-        "0xee75995da2e55e6c4938533d341597bc10add3837cfe57174f2ee755da82555c",
-        "4000",
-    );
+    let result =
+        run_json(&mock_tx, "type", "0xee75995da2e55e6c4938533d341597bc10add3837cfe57174f2ee755da82555c", "4000");
     assert_eq!(result, "{\"cycle\":3217,\"error\":null}");
 }
 
 #[test]
 pub fn test_sample_json_version1() {
     let mock_tx = read_to_string("tests/programs/sample_data1.json").unwrap();
-    let result = run_json(
-        &mock_tx,
-        "type",
-        "0xca505bee92c34ac4522d15da2c91f0e4060e4540f90a28d7202df8fe8ce930ba",
-        "4000",
-    );
+    let result =
+        run_json(&mock_tx, "type", "0xca505bee92c34ac4522d15da2c91f0e4060e4540f90a28d7202df8fe8ce930ba", "4000");
     assert_eq!(result, "{\"cycle\":3219,\"error\":null}");
 }

--- a/ckb-debugger-api/tests/test_rust.rs
+++ b/ckb-debugger-api/tests/test_rust.rs
@@ -27,15 +27,7 @@ fn create_mock_cell_dep(data: Bytes, lock: Option<Script>) -> (Byte32, MockCellD
         .capacity(Capacity::bytes(data.len() + 200).unwrap().pack())
         .lock(lock.unwrap_or_else(Script::default))
         .build();
-    (
-        hash,
-        MockCellDep {
-            cell_dep,
-            output: cell_output,
-            data,
-            header: None,
-        },
-    )
+    (hash, MockCellDep { cell_dep, output: cell_output, data, header: None })
 }
 
 #[test]
@@ -68,29 +60,15 @@ pub fn test_bench() {
         .cell_dep(data_dep.cell_dep.clone())
         .cell_dep(code_dep.cell_dep.clone())
         .build();
-    let mock_input = MockInput {
-        input: cell_input,
-        output: input_dep.output,
-        data: input_dep.data,
-        header: None,
-    };
+    let mock_input = MockInput { input: cell_input, output: input_dep.output, data: input_dep.data, header: None };
     let mock_info = MockInfo {
         inputs: vec![mock_input],
         cell_deps: vec![data_dep, code_dep],
         header_deps: vec![],
         extensions: vec![],
     };
-    let mock_transaction = MockTransaction {
-        mock_info,
-        tx: transaction.data(),
-    };
+    let mock_transaction = MockTransaction { mock_info, tx: transaction.data() };
 
-    let result = run(
-        &mock_transaction,
-        &ScriptGroupType::Lock,
-        &script_hash,
-        20_000_000,
-        None,
-    );
+    let result = run(&mock_transaction, &ScriptGroupType::Lock, &script_hash, 20_000_000, None);
     assert_eq!(result.unwrap(), 58897);
 }

--- a/ckb-debugger/src/decode.rs
+++ b/ckb-debugger/src/decode.rs
@@ -1,10 +1,9 @@
+use ckb_vm::instructions::*;
+use ckb_vm::machine::VERSION2;
+
 pub fn decode_instruction(data: &str) -> Result<(), Box<dyn std::error::Error>> {
     let instruction =
         if data.starts_with("0x") { u32::from_str_radix(&data[2..], 16)? } else { u32::from_str_radix(data, 10)? };
-
-    use ckb_vm::instructions::*;
-    use ckb_vm::machine::VERSION2;
-
     let (ins, isa) = if let Some(i) = i::factory::<u64>(instruction, VERSION2) {
         let tagged_instruction: tagged::TaggedInstruction = tagged::TaggedInstruction::try_from(i).unwrap();
         (tagged_instruction.to_string(), "I")
@@ -14,12 +13,12 @@ pub fn decode_instruction(data: &str) -> Result<(), Box<dyn std::error::Error>> 
     } else if let Some(i) = a::factory::<u64>(instruction, VERSION2) {
         let tagged_instruction = tagged::TaggedInstruction::try_from(i).unwrap();
         (tagged_instruction.to_string(), "A")
-    } else if let Some(i) = b::factory::<u64>(instruction, VERSION2) {
-        let tagged_instruction = tagged::TaggedInstruction::try_from(i).unwrap();
-        (tagged_instruction.to_string(), "B")
     } else if let Some(i) = rvc::factory::<u64>(instruction, VERSION2) {
         let tagged_instruction = tagged::TaggedInstruction::try_from(i).unwrap();
         (tagged_instruction.to_string(), "C")
+    } else if let Some(i) = b::factory::<u64>(instruction, VERSION2) {
+        let tagged_instruction = tagged::TaggedInstruction::try_from(i).unwrap();
+        (tagged_instruction.to_string(), "B")
     } else {
         ("?".to_string(), "?")
     };

--- a/ckb-debugger/src/decode.rs
+++ b/ckb-debugger/src/decode.rs
@@ -1,9 +1,6 @@
 pub fn decode_instruction(data: &str) -> Result<(), Box<dyn std::error::Error>> {
-    let instruction = if data.starts_with("0x") {
-        u32::from_str_radix(&data[2..], 16)?
-    } else {
-        u32::from_str_radix(data, 10)?
-    };
+    let instruction =
+        if data.starts_with("0x") { u32::from_str_radix(&data[2..], 16)? } else { u32::from_str_radix(data, 10)? };
 
     use ckb_vm::instructions::*;
     use ckb_vm::machine::VERSION2;

--- a/ckb-debugger/src/main.rs
+++ b/ckb-debugger/src/main.rs
@@ -205,11 +205,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let verifier_args: Vec<String> = matches_args.into_iter().map(|s| s.into()).collect();
     let verifier_args_byte: Vec<Bytes> = verifier_args.into_iter().map(|s| s.into()).collect();
 
-    let fs_syscall = if let Some(file_name) = matches_read_file_name {
-        Some(FileStream::new(file_name))
-    } else {
-        None
-    };
+    let fs_syscall = if let Some(file_name) = matches_read_file_name { Some(FileStream::new(file_name)) } else { None };
 
     let verifier_max_cycles: u64 = matches_max_cycles.parse()?;
     let verifier_mock_tx: MockTransaction = {
@@ -235,11 +231,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         repr_mock_tx.into()
     };
     let verifier_script_group_type = {
-        let script_group_type = if matches_tx_file.is_none() {
-            "type"
-        } else {
-            matches_script_group_type.unwrap()
-        };
+        let script_group_type = if matches_tx_file.is_none() { "type" } else { matches_script_group_type.unwrap() };
         from_plain_str(script_group_type)?
     };
     let verifier_script_hash = if matches_tx_file.is_none() {
@@ -330,11 +322,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             verifier.generate_syscalls(verifier_script_version, verifier_script_group, machine_context.clone());
         machine_builder =
             machine_syscalls.into_iter().fold(machine_builder, |builder, syscall| builder.syscall(syscall));
-        let machine_builder = if let Some(fs) = fs_syscall.clone() {
-            machine_builder.syscall(Box::new(fs))
-        } else {
-            machine_builder
-        };
+        let machine_builder =
+            if let Some(fs) = fs_syscall.clone() { machine_builder.syscall(Box::new(fs)) } else { machine_builder };
         let machine_builder = machine_builder.syscall(Box::new(TimeNow::new()));
         let machine_builder = machine_builder.syscall(Box::new(Random::new()));
         let machine_builder = machine_builder.syscall(Box::new(FileOperation::new()));
@@ -386,18 +375,11 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         let bytes = machine.load_program(&verifier_program, &verifier_args_byte)?;
         let transferred_cycles = transferred_byte_cycles(bytes);
         machine.machine.add_cycles(transferred_cycles)?;
-        let result = if matches_step > 0 {
-            machine_step(&mut machine)
-        } else {
-            machine.run()
-        };
+        let result = if matches_step > 0 { machine_step(&mut machine) } else { machine.run() };
         match result {
             Ok(data) => {
                 println!("Run result: {:?}", data);
-                println!(
-                    "Total cycles consumed: {}",
-                    HumanReadableCycles(machine.machine.cycles())
-                );
+                println!("Total cycles consumed: {}", HumanReadableCycles(machine.machine.cycles()));
                 println!(
                     "Transfer cycles: {}, running cycles: {}",
                     HumanReadableCycles(transferred_cycles),
@@ -555,16 +537,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                         probe!(ckb_vm, execute_inst, pc, cycles, inst, regs, memory);
                         let r = execute(inst, &mut machine);
                         let cycles = machine.cycles();
-                        probe!(
-                            ckb_vm,
-                            execute_inst_end,
-                            pc,
-                            cycles,
-                            inst,
-                            regs,
-                            memory,
-                            if r.is_ok() { 0 } else { 1 }
-                        );
+                        probe!(ckb_vm, execute_inst_end, pc, cycles, inst, regs, memory, if r.is_ok() { 0 } else { 1 });
                         r
                     });
             }

--- a/ckb-debugger/src/misc.rs
+++ b/ckb-debugger/src/misc.rs
@@ -40,10 +40,7 @@ lazy_static! {
 
 impl Default for FileStream {
     fn default() -> Self {
-        Self {
-            content: Default::default(),
-            offset: 0,
-        }
+        Self { content: Default::default(), offset: 0 }
     }
 }
 
@@ -211,10 +208,7 @@ impl<Mac: SupportMachine> Syscalls<Mac> for FileOperation {
                 let path = Self::fetch_string(machine, arg0)?;
                 let mode = Self::fetch_string(machine, arg1)?;
                 let handler = unsafe {
-                    fopen(
-                        path.as_bytes().as_ptr() as *const c_char,
-                        mode.as_bytes().as_ptr() as *const c_char,
-                    )
+                    fopen(path.as_bytes().as_ptr() as *const c_char, mode.as_bytes().as_ptr() as *const c_char)
                 };
                 machine.set_register(A0, Mac::REG::from_u64(handler as u64));
             }
@@ -242,12 +236,7 @@ impl<Mac: SupportMachine> Syscalls<Mac> for FileOperation {
                 }
                 let buf = vec![0u8; total_size as usize];
                 let read_count = unsafe {
-                    fread(
-                        buf.as_ptr() as *mut c_void,
-                        size as size_t,
-                        nitems as size_t,
-                        stream as *mut FILE,
-                    )
+                    fread(buf.as_ptr() as *mut c_void, size as size_t, nitems as size_t, stream as *mut FILE)
                 };
                 machine.memory_mut().store_bytes(ptr, &buf[0..read_count * size as usize])?;
                 machine.set_register(A0, Mac::REG::from_u64(read_count as u64));

--- a/ckb-gdb-remote-protocol/src/libc_fs.rs
+++ b/ckb-gdb-remote-protocol/src/libc_fs.rs
@@ -165,12 +165,7 @@ impl FileSystem for LibcFS {
 
             // Fill bytes as many as `read` bytes
             let read: isize = unsafe {
-                libc::pread(
-                    fd as libc::c_int,
-                    buf.as_mut_ptr() as *mut libc::c_void,
-                    count,
-                    offset as libc::off_t,
-                )
+                libc::pread(fd as libc::c_int, buf.as_mut_ptr() as *mut libc::c_void, count, offset as libc::off_t)
             };
 
             if read >= 0 {
@@ -188,12 +183,7 @@ impl FileSystem for LibcFS {
         Ok((|| {
             // Write data, as much as `written` bytes of data
             let written: isize = unsafe {
-                libc::pwrite(
-                    fd as libc::c_int,
-                    data.as_ptr() as *const libc::c_void,
-                    data.len(),
-                    offset as libc::off_t,
-                )
+                libc::pwrite(fd as libc::c_int, data.as_ptr() as *const libc::c_void, data.len(), offset as libc::off_t)
             };
 
             if written >= 0 {

--- a/ckb-gdb-remote-protocol/tests/integration.rs
+++ b/ckb-gdb-remote-protocol/tests/integration.rs
@@ -25,10 +25,7 @@ struct TestHandler {
 
 impl Default for TestHandler {
     fn default() -> TestHandler {
-        TestHandler {
-            process_type: ProcessType::Created,
-            stop_reason: StopReason::Exited(23, 0),
-        }
+        TestHandler { process_type: ProcessType::Created, stop_reason: StopReason::Exited(23, 0) }
     }
 }
 
@@ -55,16 +52,8 @@ impl GDBTestBuilder {
     where
         T: AsRef<str>,
     {
-        let GDBTestBuilder {
-            assert,
-            handler,
-            listener,
-        } = self;
-        GDBTestBuilder {
-            assert: assert.with_args(&["-ex", cmd.as_ref()]),
-            handler,
-            listener,
-        }
+        let GDBTestBuilder { assert, handler, listener } = self;
+        GDBTestBuilder { assert: assert.with_args(&["-ex", cmd.as_ref()]), handler, listener }
     }
 
     /// Add assertions for the GDB process. `f` will receive an `Assert` that can
@@ -73,17 +62,9 @@ impl GDBTestBuilder {
     where
         F: FnOnce(Assert) -> Assert,
     {
-        let GDBTestBuilder {
-            assert,
-            handler,
-            listener,
-        } = self;
+        let GDBTestBuilder { assert, handler, listener } = self;
         let assert = f(assert);
-        GDBTestBuilder {
-            assert,
-            handler,
-            listener,
-        }
+        GDBTestBuilder { assert, handler, listener }
     }
 
     /// Change the behavior of the `TestHandler`. `f` will receive a `&mut TestHandler` argument
@@ -92,35 +73,19 @@ impl GDBTestBuilder {
     where
         F: FnOnce(&mut TestHandler),
     {
-        let GDBTestBuilder {
-            assert,
-            mut handler,
-            listener,
-        } = self;
+        let GDBTestBuilder { assert, mut handler, listener } = self;
         f(&mut handler);
-        GDBTestBuilder {
-            assert,
-            handler,
-            listener,
-        }
+        GDBTestBuilder { assert, handler, listener }
     }
 
     /// Run the prepared test, panicing on failure.
     fn execute(self) {
-        let GDBTestBuilder {
-            assert,
-            handler,
-            listener,
-        } = self;
+        let GDBTestBuilder { assert, handler, listener } = self;
         let assert = assert.with_args(&["-ex", "quit"]);
         // Run the server on a background thread.
         let handle = thread::spawn(move || {
             let (stream, _) = listener.accept().expect("Listener's accept failed!");
-            process_packets_from(
-                stream.try_clone().expect("TCPStream::try_clone failed!"),
-                stream,
-                handler,
-            );
+            process_packets_from(stream.try_clone().expect("TCPStream::try_clone failed!"), stream, handler);
         });
         debug!("Running GDB as {:?}", assert);
         assert.unwrap();
@@ -140,11 +105,7 @@ fn gdb_test() -> GDBTestBuilder {
     let remote_cmd = format!("target remote {}", addr);
     let assert = Assert::command(&[&gdb_s, "-nx", "-batch", "-ex", &remote_cmd]);
     let handler = Default::default();
-    GDBTestBuilder {
-        assert,
-        handler,
-        listener,
-    }
+    GDBTestBuilder { assert, handler, listener }
 }
 
 #[test]

--- a/ckb-mock-tx-types/src/lib.rs
+++ b/ckb-mock-tx-types/src/lib.rs
@@ -55,11 +55,7 @@ impl MockTransaction {
     ) -> Result<Option<(CellOutput, Bytes, Option<Byte32>)>, String> {
         for mock_input in &self.mock_info.inputs {
             if input == &mock_input.input {
-                return Ok(Some((
-                    mock_input.output.clone(),
-                    mock_input.data.clone(),
-                    mock_input.header.clone(),
-                )));
+                return Ok(Some((mock_input.output.clone(), mock_input.data.clone(), mock_input.header.clone())));
             }
         }
         live_cell_getter(input.previous_output())
@@ -72,11 +68,7 @@ impl MockTransaction {
     ) -> Result<Option<(CellOutput, Bytes, Option<Byte32>)>, String> {
         for mock_cell in &self.mock_info.cell_deps {
             if out_point == &mock_cell.cell_dep.out_point() {
-                return Ok(Some((
-                    mock_cell.output.clone(),
-                    mock_cell.data.clone(),
-                    mock_cell.header.clone(),
-                )));
+                return Ok(Some((mock_cell.output.clone(), mock_cell.data.clone(), mock_cell.header.clone())));
             }
         }
         live_cell_getter(out_point.clone())
@@ -183,21 +175,12 @@ impl Resource {
             mock_tx.mock_info.extensions.iter().map(|(hash, data)| (hash.clone(), data.pack())).collect();
         extensions.extend(block_extensions);
 
-        Ok(Resource {
-            required_cells,
-            required_headers,
-            block_extensions: extensions,
-        })
+        Ok(Resource { required_cells, required_headers, block_extensions: extensions })
     }
 
     fn build_transaction_info(header: Option<Byte32>) -> TransactionInfo {
         // Only block hash might be used by script syscalls
-        TransactionInfo::new(
-            0,
-            EpochNumberWithFraction::new(0, 0, 1800),
-            header.unwrap_or_default(),
-            0,
-        )
+        TransactionInfo::new(0, EpochNumberWithFraction::new(0, 0, 1800), header.unwrap_or_default(), 0)
     }
 }
 
@@ -354,18 +337,12 @@ impl From<ReprMockInfo> for MockInfo {
 
 impl From<MockTransaction> for ReprMockTransaction {
     fn from(tx: MockTransaction) -> ReprMockTransaction {
-        ReprMockTransaction {
-            mock_info: tx.mock_info.into(),
-            tx: tx.tx.into(),
-        }
+        ReprMockTransaction { mock_info: tx.mock_info.into(), tx: tx.tx.into() }
     }
 }
 impl From<ReprMockTransaction> for MockTransaction {
     fn from(tx: ReprMockTransaction) -> MockTransaction {
-        MockTransaction {
-            mock_info: tx.mock_info.into(),
-            tx: tx.tx.into(),
-        }
+        MockTransaction { mock_info: tx.mock_info.into(), tx: tx.tx.into() }
     }
 }
 

--- a/ckb-vm-debug-utils/src/elf_dumper.rs
+++ b/ckb-vm-debug-utils/src/elf_dumper.rs
@@ -16,21 +16,13 @@ pub struct ElfDumper {
 
 impl Default for ElfDumper {
     fn default() -> ElfDumper {
-        ElfDumper {
-            dump_file_name: "dump.bin".to_string(),
-            syscall_number: 4097,
-            maximum_zero_gap: 64,
-        }
+        ElfDumper { dump_file_name: "dump.bin".to_string(), syscall_number: 4097, maximum_zero_gap: 64 }
     }
 }
 
 impl ElfDumper {
     pub fn new(dump_file_name: String, syscall_number: u64, maximum_zero_gap: u64) -> Self {
-        ElfDumper {
-            dump_file_name,
-            syscall_number,
-            maximum_zero_gap,
-        }
+        ElfDumper { dump_file_name, syscall_number, maximum_zero_gap }
     }
 }
 
@@ -90,11 +82,8 @@ impl<Mac: SupportMachine> Syscalls<Mac> for ElfDumper {
                         let same_page = page == last_segment.last_page();
                         let gap = start - (last_segment.start + last_segment.data.len() as u64);
                         if last_segment.executable == executable && ((gap <= self.maximum_zero_gap) || same_page) {
-                            let Segment {
-                                start: segment_start,
-                                data: segment_data,
-                                ..
-                            } = segments.remove(segments.len() - 1);
+                            let Segment { start: segment_start, data: segment_data, .. } =
+                                segments.remove(segments.len() - 1);
                             let mut segment_data = BytesMut::from(segment_data.as_ref());
                             // Fill in gap first
                             let mut zeros = vec![];
@@ -117,11 +106,7 @@ impl<Mac: SupportMachine> Syscalls<Mac> for ElfDumper {
                         start += 8;
                     }
 
-                    segments.push(Segment {
-                        start: bytes_start,
-                        data: bytes_mut.freeze(),
-                        executable,
-                    });
+                    segments.push(Segment { start: bytes_start, data: bytes_mut.freeze(), executable });
                 }
             }
             page += 1;
@@ -187,11 +172,7 @@ impl<Mac: SupportMachine> Syscalls<Mac> for ElfDumper {
         register_buffer.put_u32_le(jump_instruction);
         assert!(register_buffer.len() < RISCV_PAGESIZE);
 
-        segments.push(Segment {
-            start: register_buffer_start,
-            data: register_buffer.freeze(),
-            executable: true,
-        });
+        segments.push(Segment { start: register_buffer_start, data: register_buffer.freeze(), executable: true });
 
         // Piece everything together into an ELF binary
         let mut elf = BytesMut::new();
@@ -319,10 +300,7 @@ impl<Mac: SupportMachine> Syscalls<Mac> for ElfDumper {
             elf.put_u8(0);
         }
         let current_offset = elf.len() as u64;
-        LittleEndian::write_u64(
-            &mut elf[program_header_offset..program_header_offset + 8],
-            current_offset,
-        );
+        LittleEndian::write_u64(&mut elf[program_header_offset..program_header_offset + 8], current_offset);
         LittleEndian::write_u16(
             &mut elf[program_header_number_offset..program_header_number_offset + 8],
             program_headers.len() as u16,
@@ -335,10 +313,7 @@ impl<Mac: SupportMachine> Syscalls<Mac> for ElfDumper {
             elf.put_u8(0);
         }
         let current_offset = elf.len() as u64;
-        LittleEndian::write_u64(
-            &mut elf[section_header_offset..section_header_offset + 8],
-            current_offset,
-        );
+        LittleEndian::write_u64(&mut elf[section_header_offset..section_header_offset + 8], current_offset);
         LittleEndian::write_u16(
             &mut elf[section_header_number_offset..section_header_number_offset + 8],
             section_headers.len() as u16,

--- a/ckb-vm-debug-utils/src/gdbserver.rs
+++ b/ckb-vm-debug-utils/src/gdbserver.rs
@@ -12,10 +12,7 @@ use std::borrow::Cow;
 use std::cell::RefCell;
 
 fn show_warning(e: &CkbError) {
-    println!(
-        "Fatal error in ckb-vm occurred: {:?}. Press Ctrl+C to quit or use gdb to attach it.",
-        e
-    );
+    println!("Fatal error in ckb-vm occurred: {:?}. Press Ctrl+C to quit or use gdb to attach it.", e);
     println!("Note: it doesn't mean any coding error in ckb-vm.");
     println!("This session can't be re-used. It is paused for post-mortem.")
 }
@@ -36,19 +33,12 @@ impl WatchPointStatus {
     fn new(wp: Watchpoint) -> Self {
         let mut data = Vec::<u8>::new();
         data.resize(wp.n_bytes as usize, 0);
-        WatchPointStatus {
-            watchpoint: wp,
-            data,
-            has_data: false,
-        }
+        WatchPointStatus { watchpoint: wp, data, has_data: false }
     }
     fn has_change<H: Handler>(&mut self, handler: &H) -> Result<bool, Error> {
         let has_data = self.has_data;
 
-        let mem = MemoryRegion {
-            address: self.watchpoint.addr,
-            length: self.watchpoint.n_bytes,
-        };
+        let mem = MemoryRegion { address: self.watchpoint.addr, length: self.watchpoint.n_bytes };
         let new_content = handler.read_memory(mem)?;
         let result = if new_content == self.data {
             Ok(false)
@@ -275,10 +265,7 @@ impl<M: Memory<REG = u64>> Handler for GdbHandler<M> {
     fn insert_write_watchpoint(&self, watchpoint: Watchpoint) -> Result<(), Error> {
         let wp = WatchPointStatus::new(watchpoint);
         self.watchpoints.borrow_mut().push(wp);
-        debug!(
-            "insert watch point at {:x} with length {}",
-            watchpoint.addr, watchpoint.n_bytes
-        );
+        debug!("insert watch point at {:x} with length {}", watchpoint.addr, watchpoint.n_bytes);
         Ok(())
     }
     fn remove_write_watchpoint(&self, wp: Watchpoint) -> Result<(), Error> {

--- a/ckb-vm-debug-utils/src/gdbstub.rs
+++ b/ckb-vm-debug-utils/src/gdbstub.rs
@@ -298,12 +298,7 @@ impl<
         let value = match reg_id {
             RiscvRegId::Pc => self.machine.pc(),
             RiscvRegId::Gpr(idx) => &self.machine.registers()[idx as usize],
-            _ => {
-                return Err(TargetError::Fatal(Error::External(format!(
-                    "Invalid register id: {:?}",
-                    reg_id
-                ))))
-            }
+            _ => return Err(TargetError::Fatal(Error::External(format!("Invalid register id: {:?}", reg_id)))),
         };
         buf.copy_from_slice(&value.to_u64().to_le_bytes()[0..(R::BITS as usize / 8)]);
         Ok(buf.len())
@@ -321,12 +316,7 @@ impl<
             RiscvRegId::Gpr(idx) => {
                 self.machine.set_register(idx as usize, v);
             }
-            _ => {
-                return Err(TargetError::Fatal(Error::External(format!(
-                    "Invalid register id: {:?}",
-                    reg_id
-                ))))
-            }
+            _ => return Err(TargetError::Fatal(Error::External(format!("Invalid register id: {:?}", reg_id)))),
         };
 
         Ok(())
@@ -527,16 +517,12 @@ impl<
             VmEvent::DoneStep => Event::TargetStopped(SingleThreadStopReason::DoneStep),
             VmEvent::Exited(code) => Event::TargetStopped(SingleThreadStopReason::Exited(code)),
             VmEvent::Break => Event::TargetStopped(SingleThreadStopReason::SwBreak(())),
-            VmEvent::WatchRead(addr) => Event::TargetStopped(SingleThreadStopReason::Watch {
-                tid: (),
-                kind: WatchKind::Read,
-                addr,
-            }),
-            VmEvent::WatchWrite(addr) => Event::TargetStopped(SingleThreadStopReason::Watch {
-                tid: (),
-                kind: WatchKind::Write,
-                addr,
-            }),
+            VmEvent::WatchRead(addr) => {
+                Event::TargetStopped(SingleThreadStopReason::Watch { tid: (), kind: WatchKind::Read, addr })
+            }
+            VmEvent::WatchWrite(addr) => {
+                Event::TargetStopped(SingleThreadStopReason::Watch { tid: (), kind: WatchKind::Write, addr })
+            }
             VmEvent::CatchSyscall(number) => Event::TargetStopped(SingleThreadStopReason::CatchSyscall {
                 tid: None,
                 number,

--- a/ckb-vm-pprof-converter/src/main.rs
+++ b/ckb-vm-pprof-converter/src/main.rs
@@ -60,14 +60,10 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         let mut stack: Vec<Symbol> = line[0..i]
             .split("; ")
             .map(|s| match s.find(":") {
-                Some(j) => Symbol {
-                    file: Some(s[0..j].to_string()),
-                    name: Some(normalize_function_name(&s[j + 1..s.len()])),
-                },
-                None => Symbol {
-                    name: Some(normalize_function_name(s)),
-                    file: None,
-                },
+                Some(j) => {
+                    Symbol { file: Some(s[0..j].to_string()), name: Some(normalize_function_name(&s[j + 1..s.len()])) }
+                }
+                None => Symbol { name: Some(normalize_function_name(s)), file: None },
             })
             .collect();
         stack.reverse();
@@ -120,16 +116,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                 ..Default::default()
             };
             functions.insert(name, function_id);
-            let line = profile::Line {
-                function_id,
-                line: 0,
-                ..Default::default()
-            };
-            let loc = profile::Location {
-                id: function_id,
-                line: vec![line].into(),
-                ..Default::default()
-            };
+            let line = profile::Line { function_id, line: 0, ..Default::default() };
+            let loc = profile::Location { id: function_id, line: vec![line].into(), ..Default::default() };
             // the fn_tbl has the same length with loc_tbl
             fn_tbl.push(function);
             loc_tbl.push(loc);
@@ -144,16 +132,10 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         };
         samples.push(sample);
     }
-    let samples_value = profile::ValueType {
-        field_type: strings[CYCLES] as i64,
-        unit: strings[COUNT] as i64,
-        ..Default::default()
-    };
-    let time_value = profile::ValueType {
-        field_type: strings[CPU] as i64,
-        unit: strings[NANOSECONDS] as i64,
-        ..Default::default()
-    };
+    let samples_value =
+        profile::ValueType { field_type: strings[CYCLES] as i64, unit: strings[COUNT] as i64, ..Default::default() };
+    let time_value =
+        profile::ValueType { field_type: strings[CPU] as i64, unit: strings[NANOSECONDS] as i64, ..Default::default() };
     let profile = profile::Profile {
         sample_type: vec![samples_value, time_value.clone()].into(),
         sample: samples.into(),

--- a/ckb-vm-pprof/res/fib.svg
+++ b/ckb-vm-pprof/res/fib.svg
@@ -1,7 +1,8 @@
 <?xml version="1.0" standalone="no"?><!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd"><svg version="1.1" width="1200" height="198" onload="init(evt)" viewBox="0 0 1200 198" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:fg="http://github.com/jonhoo/inferno"><!--Flame graph stack visualization. See https://github.com/brendangregg/FlameGraph for latest version, and http://www.brendangregg.com/flamegraphs.html for examples.--><!--NOTES: --><defs><linearGradient id="background" y1="0" y2="1" x1="0" x2="0"><stop stop-color="#eeeeee" offset="5%"/><stop stop-color="#eeeeb0" offset="95%"/></linearGradient></defs><style type="text/css">
-text { font-family:"Verdana"; font-size:12px; fill:rgb(0,0,0); }
+text { font-family:monospace; font-size:12px }
 #title { text-anchor:middle; font-size:17px; }
-#search { opacity:0.1; cursor:pointer; }
+#matched { text-anchor:end; }
+#search { text-anchor:end; opacity:0.1; cursor:pointer; }
 #search:hover, #search.show { opacity:1; }
 #subtitle { text-anchor:middle; font-color:rgb(160,160,160); }
 #unzoom { cursor:pointer; }
@@ -18,7 +19,7 @@ text { font-family:"Verdana"; font-size:12px; fill:rgb(0,0,0); }
         var fluiddrawing = true;
         var truncate_text_right = false;
     ]]><![CDATA["use strict";
-var details, searchbtn, unzoombtn, matchedtxt, svg, searching, frames;
+var details, searchbtn, unzoombtn, matchedtxt, svg, searching, frames, known_font_width;
 function init(evt) {
     details = document.getElementById("details").firstChild;
     searchbtn = document.getElementById("search");
@@ -26,6 +27,7 @@ function init(evt) {
     matchedtxt = document.getElementById("matched");
     svg = document.getElementsByTagName("svg")[0];
     frames = document.getElementById("frames");
+    known_font_width = get_monospace_width(frames);
     total_samples = parseInt(frames.attributes.total_samples.value);
     searching = 0;
 
@@ -44,7 +46,7 @@ function init(evt) {
         // Edge requires us to have a viewBox that gets updated with size changes.
         var isEdge = /Edge\/\d./i.test(navigator.userAgent);
         if (!isEdge) {
-          svg.removeAttribute("viewBox");
+            svg.removeAttribute("viewBox");
         }
         var update_for_width_change = function() {
             if (isEdge) {
@@ -55,15 +57,12 @@ function init(evt) {
             frames.attributes.width.value = svg.width.baseVal.value - xpad * 2;
 
             // Text truncation needs to be adjusted for the current width.
-            var el = frames.children;
-            for(var i = 0; i < el.length; i++) {
-                update_text(el[i]);
-            }
+            update_text_for_elements(frames.children);
 
             // Keep search elements at a fixed distance from right edge.
             var svgWidth = svg.width.baseVal.value;
-            searchbtn.attributes.x.value = svgWidth - xpad - 100;
-            matchedtxt.attributes.x.value = svgWidth - xpad - 100;
+            searchbtn.attributes.x.value = svgWidth - xpad;
+            matchedtxt.attributes.x.value = svgWidth - xpad;
         };
         window.addEventListener('resize', function() {
             update_for_width_change();
@@ -181,12 +180,88 @@ function g_to_func(e) {
     // name before it's searched, do it here before returning.
     return (func);
 }
+function get_monospace_width(frames) {
+    // Given the id="frames" element, return the width of text characters if
+    // this is a monospace font, otherwise return 0.
+    text = find_child(frames.children[0], "text");
+    originalContent = text.textContent;
+    text.textContent = "!";
+    bangWidth = text.getComputedTextLength();
+    text.textContent = "W";
+    wWidth = text.getComputedTextLength();
+    text.textContent = originalContent;
+    if (bangWidth === wWidth) {
+        return bangWidth;
+    } else {
+        return 0;
+    }
+}
+function update_text_for_elements(elements) {
+    // In order to render quickly in the browser, you want to do one pass of
+    // reading attributes, and one pass of mutating attributes. See
+    // https://web.dev/avoid-large-complex-layouts-and-layout-thrashing/ for details.
+
+    // Fall back to inefficient calculation, if we're variable-width font.
+    // TODO This should be optimized somehow too.
+    if (known_font_width === 0) {
+        for (var i = 0; i < elements.length; i++) {
+            update_text(elements[i]);
+        }
+        return;
+    }
+
+    var textElemNewAttributes = [];
+    for (var i = 0; i < elements.length; i++) {
+        var e = elements[i];
+        var r = find_child(e, "rect");
+        var t = find_child(e, "text");
+        var w = parseFloat(r.attributes.width.value) * frames.attributes.width.value / 100 - 3;
+        var txt = find_child(e, "title").textContent.replace(/\([^(]*\)$/,"");
+        var newX = format_percent((parseFloat(r.attributes.x.value) + (100 * 3 / frames.attributes.width.value)));
+
+        // Smaller than this size won't fit anything
+        if (w < 2 * known_font_width) {
+            textElemNewAttributes.push([newX, ""]);
+            continue;
+        }
+
+        // Fit in full text width
+        if (txt.length * known_font_width < w) {
+            textElemNewAttributes.push([newX, txt]);
+            continue;
+        }
+
+        var substringLength = Math.floor(w / known_font_width) - 2;
+        if (truncate_text_right) {
+            // Truncate the right side of the text.
+            textElemNewAttributes.push([newX, txt.substring(0, substringLength) + ".."]);
+            continue;
+        } else {
+            // Truncate the left side of the text.
+            textElemNewAttributes.push([newX, ".." + txt.substring(txt.length - substringLength, txt.length)]);
+            continue;
+        }
+    }
+
+    console.assert(textElemNewAttributes.length === elements.length, "Resize failed, please file a bug at https://github.com/jonhoo/inferno/");
+
+    // Now that we know new textContent, set it all in one go so we don't refresh a bazillion times.
+    for (var i = 0; i < elements.length; i++) {
+        var e = elements[i];
+        var values = textElemNewAttributes[i];
+        var t = find_child(e, "text");
+        t.attributes.x.value = values[0];
+        t.textContent = values[1];
+    }
+}
+
 function update_text(e) {
     var r = find_child(e, "rect");
     var t = find_child(e, "text");
     var w = parseFloat(r.attributes.width.value) * frames.attributes.width.value / 100 - 3;
     var txt = find_child(e, "title").textContent.replace(/\([^(]*\)$/,"");
     t.attributes.x.value = format_percent((parseFloat(r.attributes.x.value) + (100 * 3 / frames.attributes.width.value)));
+
     // Smaller than this size won't fit anything
     if (w < 2 * fontsize * fontwidth) {
         t.textContent = "";
@@ -194,7 +269,7 @@ function update_text(e) {
     }
     t.textContent = txt;
     // Fit in full text width
-    if (/^ *\$/.test(txt) || t.getComputedTextLength() < w)
+    if (t.getComputedTextLength() < w)
         return;
     if (truncate_text_right) {
         // Truncate the right side of the text.
@@ -261,6 +336,7 @@ function zoom(node) {
     var ymin = parseFloat(attr.y.value);
     unzoombtn.classList.remove("hide");
     var el = frames.children;
+    var to_update_text = [];
     for (var i = 0; i < el.length; i++) {
         var e = el[i];
         var a = find_child(e, "rect").attributes;
@@ -277,7 +353,7 @@ function zoom(node) {
             if (ex <= xmin && (ex+ew) >= xmax) {
                 e.classList.add("parent");
                 zoom_parent(e);
-                update_text(e);
+                to_update_text.push(e);
             }
             // not in current path
             else
@@ -291,10 +367,11 @@ function zoom(node) {
             }
             else {
                 zoom_child(e, xmin, width);
-                update_text(e);
+                to_update_text.push(e);
             }
         }
     }
+    update_text_for_elements(to_update_text);
 }
 function unzoom() {
     unzoombtn.classList.add("hide");
@@ -303,8 +380,8 @@ function unzoom() {
         el[i].classList.remove("parent");
         el[i].classList.remove("hide");
         zoom_reset(el[i]);
-        update_text(el[i]);
     }
+    update_text_for_elements(el);
 }
 // search
 function reset_search() {
@@ -411,4 +488,4 @@ function search(term) {
 function format_percent(n) {
     return n.toFixed(4) + "%";
 }
-]]></script><rect x="0" y="0" width="100%" height="198" fill="url(#background)"/><text id="title" x="50.0000%" y="24.00">Flame Graph</text><text id="details" x="10" y="181.00"> </text><text id="unzoom" class="hide" x="10" y="24.00">Reset Zoom</text><text id="search" x="1090" y="24.00">Search</text><text id="matched" x="1090" y="181.00"> </text><svg id="frames" x="10" width="1180" total_samples="2096"><g><title> /code/fib.c:main (781 samples, 37.26%)</title><rect x="1.5744%" y="117" width="37.2615%" height="15" fill="rgb(227,0,7)" fg:x="33" fg:w="781"/><text x="1.8244%" y="127.50"> /code/fib.c:main</text></g><g><title> /code/fib.c:fib (755 samples, 36.02%)</title><rect x="2.8149%" y="101" width="36.0210%" height="15" fill="rgb(217,0,24)" fg:x="59" fg:w="755"/><text x="3.0649%" y="111.50"> /code/fib.c:fib</text></g><g><title> /code/fib.c:fib (694 samples, 33.11%)</title><rect x="5.7252%" y="85" width="33.1107%" height="15" fill="rgb(221,193,54)" fg:x="120" fg:w="694"/><text x="5.9752%" y="95.50"> /code/fib.c:fib</text></g><g><title> /code/fib.c:fib (572 samples, 27.29%)</title><rect x="11.5458%" y="69" width="27.2901%" height="15" fill="rgb(248,212,6)" fg:x="242" fg:w="572"/><text x="11.7958%" y="79.50"> /code/fib.c:fib</text></g><g><title> /code/fib.c:fib (345 samples, 16.46%)</title><rect x="22.3760%" y="53" width="16.4599%" height="15" fill="rgb(208,68,35)" fg:x="469" fg:w="345"/><text x="22.6260%" y="63.50"> /code/fib.c:fib</text></g><g><title> /code/fib.c:fib (80 samples, 3.82%)</title><rect x="35.0191%" y="37" width="3.8168%" height="15" fill="rgb(232,128,0)" fg:x="734" fg:w="80"/><text x="35.2691%" y="47.50"> /co..</text></g><g><title> /source/riscv-newlib/newlib/libc/stdlib/__call_atexit.c:register_fini (7 samples, 0.33%)</title><rect x="42.1279%" y="101" width="0.3340%" height="15" fill="rgb(207,160,47)" fg:x="883" fg:w="7"/><text x="42.3779%" y="111.50"></text></g><g><title> /source/riscv-newlib/newlib/libc/misc/init.c:__libc_init_array (83 samples, 3.96%)</title><rect x="38.8359%" y="117" width="3.9599%" height="15" fill="rgb(228,23,34)" fg:x="814" fg:w="83"/><text x="39.0859%" y="127.50"> /so..</text></g><g><title> ??:?? (7 samples, 0.33%)</title><rect x="42.4618%" y="101" width="0.3340%" height="15" fill="rgb(218,30,26)" fg:x="890" fg:w="7"/><text x="42.7118%" y="111.50"></text></g><g><title> /source/riscv-newlib/newlib/libc/stdlib/atexit.c:atexit (42 samples, 2.00%)</title><rect x="42.7958%" y="117" width="2.0038%" height="15" fill="rgb(220,122,19)" fg:x="897" fg:w="42"/><text x="43.0458%" y="127.50"> ..</text></g><g><title> /source/riscv-newlib/newlib/libc/stdlib/__atexit.c:__register_exitproc (35 samples, 1.67%)</title><rect x="43.1298%" y="101" width="1.6698%" height="15" fill="rgb(250,228,42)" fg:x="904" fg:w="35"/><text x="43.3798%" y="111.50"></text></g><g><title> /source/riscv-newlib/libgloss/riscv/internal_syscall.h:_exit (501 samples, 23.90%)</title><rect x="45.8015%" y="101" width="23.9027%" height="15" fill="rgb(240,193,28)" fg:x="960" fg:w="501"/><text x="46.0515%" y="111.50"> /source/riscv-newlib/libgloss/riscv/i..</text></g><g><title> /source/riscv-newlib/newlib/libc/stdlib/exit.c:exit (702 samples, 33.49%)</title><rect x="44.7996%" y="117" width="33.4924%" height="15" fill="rgb(216,20,37)" fg:x="939" fg:w="702"/><text x="45.0496%" y="127.50"> /source/riscv-newlib/newlib/libc/stdlib/exit.c:exit</text></g><g><title> /source/riscv-newlib/newlib/libc/stdlib/__call_atexit.c:__call_exitprocs (180 samples, 8.59%)</title><rect x="69.7042%" y="101" width="8.5878%" height="15" fill="rgb(206,188,39)" fg:x="1461" fg:w="180"/><text x="69.9542%" y="111.50"> /source/ris..</text></g><g><title> /source/riscv-newlib/newlib/libc/misc/fini.c:__libc_fini_array (68 samples, 3.24%)</title><rect x="75.0477%" y="85" width="3.2443%" height="15" fill="rgb(217,207,13)" fg:x="1573" fg:w="68"/><text x="75.2977%" y="95.50"> /s..</text></g><g><title> ??:?? (27 samples, 1.29%)</title><rect x="77.0038%" y="69" width="1.2882%" height="15" fill="rgb(231,73,38)" fg:x="1614" fg:w="27"/><text x="77.2538%" y="79.50"></text></g><g><title>all (2,096 samples, 100%)</title><rect x="0.0000%" y="149" width="100.0000%" height="15" fill="rgb(225,20,46)" fg:x="0" fg:w="2096"/><text x="0.2500%" y="159.50"></text></g><g><title>??:?? (2,096 samples, 100.00%)</title><rect x="0.0000%" y="133" width="100.0000%" height="15" fill="rgb(210,31,41)" fg:x="0" fg:w="2096"/><text x="0.2500%" y="143.50">??:??</text></g><g><title> ??:?? (455 samples, 21.71%)</title><rect x="78.2920%" y="117" width="21.7080%" height="15" fill="rgb(221,200,47)" fg:x="1641" fg:w="455"/><text x="78.5420%" y="127.50"> ??:??</text></g></svg></svg>
+]]></script><rect x="0" y="0" width="100%" height="198" fill="url(#background)"/><text id="title" fill="rgb(0,0,0)" x="50.0000%" y="24.00">Flame Graph</text><text id="details" fill="rgb(0,0,0)" x="10" y="181.00"> </text><text id="unzoom" class="hide" fill="rgb(0,0,0)" x="10" y="24.00">Reset Zoom</text><text id="search" fill="rgb(0,0,0)" x="1190" y="24.00">Search</text><text id="matched" fill="rgb(0,0,0)" x="1190" y="181.00"> </text><svg id="frames" x="10" width="1180" total_samples="2093"><g><title> /code/fib.c:main (781 samples, 37.31%)</title><rect x="1.4333%" y="117" width="37.3149%" height="15" fill="rgb(227,0,7)" fg:x="30" fg:w="781"/><text x="1.6833%" y="127.50"> /code/fib.c:main</text></g><g><title> /code/fib.c:fib (755 samples, 36.07%)</title><rect x="2.6756%" y="101" width="36.0726%" height="15" fill="rgb(217,0,24)" fg:x="56" fg:w="755"/><text x="2.9256%" y="111.50"> /code/fib.c:fib</text></g><g><title> /code/fib.c:fib (694 samples, 33.16%)</title><rect x="5.5901%" y="85" width="33.1581%" height="15" fill="rgb(221,193,54)" fg:x="117" fg:w="694"/><text x="5.8401%" y="95.50"> /code/fib.c:fib</text></g><g><title> /code/fib.c:fib (572 samples, 27.33%)</title><rect x="11.4190%" y="69" width="27.3292%" height="15" fill="rgb(248,212,6)" fg:x="239" fg:w="572"/><text x="11.6690%" y="79.50"> /code/fib.c:fib</text></g><g><title> /code/fib.c:fib (345 samples, 16.48%)</title><rect x="22.2647%" y="53" width="16.4835%" height="15" fill="rgb(208,68,35)" fg:x="466" fg:w="345"/><text x="22.5147%" y="63.50"> /code/fib.c:fib</text></g><g><title> /code/fib.c:fib (80 samples, 3.82%)</title><rect x="34.9259%" y="37" width="3.8223%" height="15" fill="rgb(232,128,0)" fg:x="731" fg:w="80"/><text x="35.1759%" y="47.50"> /co..</text></g><g><title> /source/riscv-newlib/newlib/libc/machine/riscv/memset.S:func_0x10248 (455 samples, 21.74%)</title><rect x="38.7482%" y="117" width="21.7391%" height="15" fill="rgb(207,160,47)" fg:x="811" fg:w="455"/><text x="38.9982%" y="127.50"> /source/riscv-newlib/newlib/libc/..</text></g><g><title> /source/riscv-newlib/newlib/libc/stdlib/__call_atexit.c:register_fini (7 samples, 0.33%)</title><rect x="63.7840%" y="101" width="0.3344%" height="15" fill="rgb(228,23,34)" fg:x="1335" fg:w="7"/><text x="64.0340%" y="111.50"></text></g><g><title> /source/riscv-newlib/newlib/libc/misc/init.c:__libc_init_array (83 samples, 3.97%)</title><rect x="60.4873%" y="117" width="3.9656%" height="15" fill="rgb(218,30,26)" fg:x="1266" fg:w="83"/><text x="60.7373%" y="127.50"> /so..</text></g><g><title> ??:func_0x1012c (7 samples, 0.33%)</title><rect x="64.1185%" y="101" width="0.3344%" height="15" fill="rgb(220,122,19)" fg:x="1342" fg:w="7"/><text x="64.3685%" y="111.50"></text></g><g><title> /source/riscv-newlib/newlib/libc/stdlib/atexit.c:atexit (42 samples, 2.01%)</title><rect x="64.4529%" y="117" width="2.0067%" height="15" fill="rgb(250,228,42)" fg:x="1349" fg:w="42"/><text x="64.7029%" y="127.50"> ..</text></g><g><title> /source/riscv-newlib/newlib/libc/stdlib/__atexit.c:__register_exitproc (35 samples, 1.67%)</title><rect x="64.7874%" y="101" width="1.6722%" height="15" fill="rgb(240,193,28)" fg:x="1356" fg:w="35"/><text x="65.0374%" y="111.50"></text></g><g><title> /source/riscv-newlib/libgloss/riscv/internal_syscall.h:_exit (501 samples, 23.94%)</title><rect x="67.4630%" y="101" width="23.9369%" height="15" fill="rgb(216,20,37)" fg:x="1412" fg:w="501"/><text x="67.7130%" y="111.50"> /source/riscv-newlib/libgloss/riscv/i..</text></g><g><title>all (2,093 samples, 100%)</title><rect x="0.0000%" y="149" width="100.0000%" height="15" fill="rgb(206,188,39)" fg:x="0" fg:w="2093"/><text x="0.2500%" y="159.50"></text></g><g><title>/source/riscv-newlib/libgloss/riscv/crt0.S:func_0x100c0 (2,093 samples, 100.00%)</title><rect x="0.0000%" y="133" width="100.0000%" height="15" fill="rgb(217,207,13)" fg:x="0" fg:w="2093"/><text x="0.2500%" y="143.50">/source/riscv-newlib/libgloss/riscv/crt0.S:func_0x100c0</text></g><g><title> /source/riscv-newlib/newlib/libc/stdlib/exit.c:exit (702 samples, 33.54%)</title><rect x="66.4596%" y="117" width="33.5404%" height="15" fill="rgb(231,73,38)" fg:x="1391" fg:w="702"/><text x="66.7096%" y="127.50"> /source/riscv-newlib/newlib/libc/stdlib/exit.c:exit</text></g><g><title> /source/riscv-newlib/newlib/libc/stdlib/__call_atexit.c:__call_exitprocs (180 samples, 8.60%)</title><rect x="91.3999%" y="101" width="8.6001%" height="15" fill="rgb(225,20,46)" fg:x="1913" fg:w="180"/><text x="91.6499%" y="111.50"> /source/ris..</text></g><g><title> /source/riscv-newlib/newlib/libc/misc/fini.c:__libc_fini_array (68 samples, 3.25%)</title><rect x="96.7511%" y="85" width="3.2489%" height="15" fill="rgb(210,31,41)" fg:x="2025" fg:w="68"/><text x="97.0011%" y="95.50"> /s..</text></g><g><title> ??:func_0x100fe (27 samples, 1.29%)</title><rect x="98.7100%" y="69" width="1.2900%" height="15" fill="rgb(221,200,47)" fg:x="2066" fg:w="27"/><text x="98.9600%" y="79.50"></text></g></svg></svg>

--- a/ckb-vm-pprof/src/lib.rs
+++ b/ckb-vm-pprof/src/lib.rs
@@ -22,11 +22,13 @@ fn sprint_fun(frame_iter: &mut Addr2LineFrameIter) -> String {
     let mut s = String::from("??");
     loop {
         if let Some(data) = frame_iter.next().unwrap() {
-            let function = data.function.unwrap();
-            s = String::from(addr2line::demangle_auto(
-                Cow::from(function.raw_name().unwrap()),
-                function.language,
-            ));
+            if let Some(function) = data.function {
+                s = String::from(addr2line::demangle_auto(
+                    Cow::from(function.raw_name().unwrap()),
+                    function.language,
+                ));
+                continue;
+            }
             continue;
         }
         break;

--- a/ckb-vm-pprof/src/lib.rs
+++ b/ckb-vm-pprof/src/lib.rs
@@ -23,10 +23,7 @@ fn sprint_fun(frame_iter: &mut Addr2LineFrameIter) -> String {
     loop {
         if let Some(data) = frame_iter.next().unwrap() {
             if let Some(function) = data.function {
-                s = String::from(addr2line::demangle_auto(
-                    Cow::from(function.raw_name().unwrap()),
-                    function.language,
-                ));
+                s = String::from(addr2line::demangle_auto(Cow::from(function.raw_name().unwrap()), function.language));
                 continue;
             }
             continue;
@@ -72,15 +69,7 @@ struct TrieNode {
 
 impl TrieNode {
     fn root() -> Self {
-        Self {
-            addr: 0,
-            link: 0,
-            pc: 0,
-            parent: None,
-            childs: vec![],
-            cycles: 0,
-            regs: [[0; 32]; 2],
-        }
+        Self { addr: 0, link: 0, pc: 0, parent: None, childs: vec![], cycles: 0, regs: [[0; 32]; 2] }
     }
 }
 
@@ -94,12 +83,7 @@ pub struct Tags {
 
 impl Tags {
     fn new(addr: u64) -> Self {
-        Tags {
-            addr,
-            file: String::from("??"),
-            line: 0xffffffff,
-            func: String::from("??"),
-        }
+        Tags { addr, file: String::from("??"), line: 0xffffffff, func: String::from("??") }
     }
 
     pub fn func(&self) -> String {
@@ -217,10 +201,7 @@ impl Profile {
         if !self.disable_overlapping_detection {
             let sp = machine.registers()[SP].to_u64();
             if sp < self.sbrk_heap {
-                return Err(Error::External(format!(
-                    "Heap and stack overlapping sp={} heap={}",
-                    sp, self.sbrk_heap
-                )));
+                return Err(Error::External(format!("Heap and stack overlapping sp={} heap={}", sp, self.sbrk_heap)));
             }
         }
         let inst = decoder.decode(machine.memory_mut(), pc)?;

--- a/ckb-vm-signal-profiler/src/frames.rs
+++ b/ckb-vm-signal-profiler/src/frames.rs
@@ -94,16 +94,8 @@ impl Report {
                     ..Default::default()
                 };
                 functions.insert(name, function_id);
-                let line = protos::Line {
-                    function_id,
-                    line: symbol.line() as i64,
-                    ..Default::default()
-                };
-                let loc = protos::Location {
-                    id: function_id,
-                    line: vec![line].into(),
-                    ..Default::default()
-                };
+                let line = protos::Line { function_id, line: symbol.line() as i64, ..Default::default() };
+                let loc = protos::Location { id: function_id, line: vec![line].into(), ..Default::default() };
                 // the fn_tbl has the same length with loc_tbl
                 fn_tbl.push(function);
                 loc_tbl.push(loc);

--- a/ckb-vm-signal-profiler/src/lib.rs
+++ b/ckb-vm-signal-profiler/src/lib.rs
@@ -122,14 +122,7 @@ impl<'a> StackUnwinder<'a> {
         for (i, v) in machine.machine.registers().iter().enumerate() {
             registers[i] = Some(*v);
         }
-        Self {
-            context,
-            machine,
-            registers,
-            state: None,
-            unwind_context: gimli::UnwindContext::new(),
-            at_start: true,
-        }
+        Self { context, machine, registers, state: None, unwind_context: gimli::UnwindContext::new(), at_start: true }
     }
 
     fn unwind_info(&mut self, address: u64) -> Result<Option<UnwindInfo>, String> {
@@ -265,11 +258,7 @@ fn extract_symbol(pc: u64, context: &DebugContext) -> Symbol {
     };
     let func = sprint_fun(&mut frame_iter);
 
-    Symbol {
-        name: Some(func),
-        line,
-        file,
-    }
+    Symbol { name: Some(func), line, file }
 }
 
 extern "C" fn perf_signal_handler(_signal: c_int) {
@@ -300,10 +289,7 @@ fn build_context(program: &Bytes) -> Result<DebugContext, String> {
             .section_by_name(id.name())
             .and_then(|section| section.uncompressed_data().ok())
             .unwrap_or(Cow::Borrowed(&[]));
-        Ok(gimli::EndianArcSlice::new(
-            Arc::from(&*data),
-            gimli::RunTimeEndian::Little,
-        ))
+        Ok(gimli::EndianArcSlice::new(Arc::from(&*data), gimli::RunTimeEndian::Little))
     })
     .map_err(|e: gimli::Error| format!("dwarf load error: {}", e))?;
 
@@ -315,8 +301,5 @@ fn build_context(program: &Bytes) -> Result<DebugContext, String> {
         .ok_or_else(|| "Provided binary is missing .debug_frame section!".to_string())?;
     let debug_frame_reader = Addr2LineEndianReader::new(Arc::from(&*debug_frame_section), gimli::RunTimeEndian::Little);
 
-    Ok(DebugContext {
-        addr_context,
-        debug_frame: debug_frame_reader.into(),
-    })
+    Ok(DebugContext { addr_context, debug_frame: debug_frame_reader.into() })
 }

--- a/ckb-vm-signal-profiler/src/timer.rs
+++ b/ckb-vm-signal-profiler/src/timer.rs
@@ -36,29 +36,18 @@ pub struct Timer {
 impl Timer {
     pub fn new(frequency: c_int) -> Timer {
         let interval = 1e6 as i64 / i64::from(frequency);
-        let it_interval = Timeval {
-            tv_sec: interval / 1e6 as i64,
-            tv_usec: interval % 1e6 as i64,
-        };
+        let it_interval = Timeval { tv_sec: interval / 1e6 as i64, tv_usec: interval % 1e6 as i64 };
         let it_value = it_interval.clone();
 
         unsafe { setitimer(ITIMER_PROF, &mut Itimerval { it_interval, it_value }, null_mut()) };
 
-        Timer {
-            frequency,
-            start_time: SystemTime::now(),
-            start_instant: Instant::now(),
-        }
+        Timer { frequency, start_time: SystemTime::now(), start_instant: Instant::now() }
     }
 
     /// Returns a `ReportTiming` struct having this timer's frequency and start
     /// time; and the time elapsed since its creation as duration.
     pub fn timing(&self) -> ReportTiming {
-        ReportTiming {
-            frequency: self.frequency,
-            start_time: self.start_time,
-            duration: self.start_instant.elapsed(),
-        }
+        ReportTiming { frequency: self.frequency, start_time: self.start_time, duration: self.start_instant.elapsed() }
     }
 }
 
@@ -83,10 +72,6 @@ pub struct ReportTiming {
 
 impl Default for ReportTiming {
     fn default() -> Self {
-        Self {
-            frequency: 1,
-            start_time: SystemTime::UNIX_EPOCH,
-            duration: Default::default(),
-        }
+        Self { frequency: 1, start_time: SystemTime::UNIX_EPOCH, duration: Default::default() }
     }
 }

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,2 +1,2 @@
 max_width = 120
-chain_width = 120
+use_small_heuristics = "Max"


### PR DESCRIPTION
- Fixed crash issue in sprint_fun. I once upgraded the addr2line dependency from 0.13 to 0.17. Recently, I found that this version may panic in some cases.
- Fix cargo fmt warnings: `chain_width` cannot have a value that exceeds `max_width`. `chain_width` will be set to the same value as `max_width`
- A small optimization: Move 'use statement' to the beginning of the file.

- A small optimization: Adjust the position of the parameter parsing code.