### PR TITLE
Support lldb

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -715,6 +715,7 @@ dependencies = [
  "bytes",
  "ckb-gdb-remote-protocol",
  "ckb-vm",
+ "env_logger 0.4.3",
  "gdbstub",
  "gdbstub_arch",
  "libc",

--- a/ckb-debugger/Cargo.toml
+++ b/ckb-debugger/Cargo.toml
@@ -24,8 +24,8 @@ ckb-vm-debug-utils = { path = "../ckb-vm-debug-utils", version = "0.117.0" }
 ckb-vm-pprof = { path = "../ckb-vm-pprof", version = "0.117.0" }
 env_logger = "0.4.3"
 ckb-gdb-remote-protocol = { path = "../ckb-gdb-remote-protocol", version = "0.117.0" }
-gdbstub = "0.6.6"
-gdbstub_arch = "0.2.4"
+gdbstub = "0.7"
+gdbstub_arch = "0.3"
 hex = "0.4"
 lazy_static = "1.4.0"
 libc = "0.2.132"

--- a/ckb-debugger/src/main.rs
+++ b/ckb-debugger/src/main.rs
@@ -447,7 +447,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                     use ckb_vm_debug_utils::{GdbStubHandler, GdbStubHandlerEventLoop};
                     use gdbstub::{
                         conn::ConnectionExt,
-                        stub::{DisconnectReason, GdbStub, GdbStubError},
+                        stub::{DisconnectReason, GdbStub},
                     };
                     use gdbstub_arch::riscv::Riscv64;
                     let mut h: GdbStubHandler<_, Riscv64> = GdbStubHandler::new(machine);
@@ -466,9 +466,6 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                             }
                             DisconnectReason::Kill => Err(Error::External("GDB sent a kill command!".to_string())),
                         },
-                        Err(GdbStubError::TargetError(e)) => {
-                            Err(Error::External(format!("target encountered a fatal error: {}", e)))
-                        }
                         Err(e) => Err(Error::External(format!("gdbstub encountered a fatal error: {}", e))),
                     };
                     match result {

--- a/ckb-gdb-remote-protocol/examples/noop-server.rs
+++ b/ckb-gdb-remote-protocol/examples/noop-server.rs
@@ -1,4 +1,4 @@
-use gdb_remote_protocol::{process_packets_from, Error, Handler, ProcessType, StopReason};
+use ckb_gdb_remote_protocol::{process_packets_from, Error, Handler, ProcessType, StopReason};
 use std::net::TcpListener;
 
 struct NoopHandler;

--- a/ckb-gdb-remote-protocol/tests/integration.rs
+++ b/ckb-gdb-remote-protocol/tests/integration.rs
@@ -14,7 +14,7 @@
 extern crate log;
 
 use assert_cli::Assert;
-use gdb_remote_protocol::{process_packets_from, Error, Handler, ProcessType, StopReason};
+use ckb_gdb_remote_protocol::{process_packets_from, Error, Handler, ProcessType, StopReason};
 use std::net::TcpListener;
 use std::thread;
 

--- a/ckb-vm-debug-utils/Cargo.toml
+++ b/ckb-vm-debug-utils/Cargo.toml
@@ -18,6 +18,6 @@ ckb-gdb-remote-protocol = { path = "../ckb-gdb-remote-protocol", version = "0.11
 libc = { version = "0.2.47", optional = true }
 log = "0.4.0"
 nix = { version = "0.26.2", optional = true }
-gdbstub = "0.6.6"
-gdbstub_arch = "0.2.4"
+gdbstub = "0.7"
+gdbstub_arch = "0.3"
 env_logger = "0.4.3"

--- a/ckb-vm-debug-utils/Cargo.toml
+++ b/ckb-vm-debug-utils/Cargo.toml
@@ -20,3 +20,4 @@ log = "0.4.0"
 nix = { version = "0.26.2", optional = true }
 gdbstub = "0.6.6"
 gdbstub_arch = "0.2.4"
+env_logger = "0.4.3"

--- a/ckb-vm-debug-utils/examples/gdb_remote_protocol_debugger.rs
+++ b/ckb-vm-debug-utils/examples/gdb_remote_protocol_debugger.rs
@@ -10,7 +10,7 @@ use ckb_vm::{
 use ckb_vm_debug_utils::GdbHandler;
 #[cfg(feature = "stdio")]
 use ckb_vm_debug_utils::Stdio;
-use gdb_remote_protocol::process_packets_from;
+use ckb_gdb_remote_protocol::process_packets_from;
 use std::env;
 use std::fs::File;
 use std::io::Read;

--- a/ckb-vm-debug-utils/src/gdbstub.rs
+++ b/ckb-vm-debug-utils/src/gdbstub.rs
@@ -179,7 +179,18 @@ impl<R: Register + Debug + Eq + StdHash, M: SupportMachine + CoreMachine<REG = R
                 let mut executed_cycles = 0;
                 loop {
                     if let Some(event) = self.step() {
-                        break event;
+                        let mut continue_step = true;
+
+                        match event {
+                            VmEvent::DoneStep | VmEvent::Exited(_) | VmEvent::Break | VmEvent::Error(_) => {
+                                continue_step = false;
+                            }
+                            _ => {}
+                        };
+
+                        if !continue_step {
+                            break event;
+                        }
                     }
 
                     executed_cycles += 1;

--- a/ckb-vm-debug-utils/src/gdbstub.rs
+++ b/ckb-vm-debug-utils/src/gdbstub.rs
@@ -6,7 +6,7 @@ use ckb_vm::{
     Bytes, Error, Memory, Register,
 };
 use gdbstub::{
-    arch::{Arch, SingleStepGdbBehavior},
+    arch::Arch,
     common::Signal,
     conn::{Connection, ConnectionExt},
     stub::{
@@ -229,10 +229,6 @@ impl<
     fn support_catch_syscalls(&mut self) -> Option<CatchSyscallsOps<'_, Self>> {
         Some(self)
     }
-
-    fn guard_rail_single_step_gdb_behavior(&self) -> SingleStepGdbBehavior {
-        SingleStepGdbBehavior::Optional
-    }
 }
 
 impl<
@@ -258,7 +254,7 @@ impl<
         Ok(())
     }
 
-    fn read_addrs(&mut self, start_addr: <Self::Arch as Arch>::Usize, data: &mut [u8]) -> TargetResult<(), Self> {
+    fn read_addrs(&mut self, start_addr: <Self::Arch as Arch>::Usize, data: &mut [u8]) -> TargetResult<usize, Self> {
         for i in 0..data.len() {
             data[i] = self
                 .machine
@@ -267,7 +263,7 @@ impl<
                 .map_err(TargetError::Fatal)?
                 .to_u8();
         }
-        Ok(())
+        Ok(data.len())
     }
 
     fn write_addrs(&mut self, start_addr: <Self::Arch as Arch>::Usize, data: &[u8]) -> TargetResult<(), Self> {


### PR DESCRIPTION
* Supports only LLDB version 18 and above.
* This requires the latest [RISC-V-related](https://github.com/daniel5151/gdbstub/pull/149) commit from gdbstub, which has not been officially released yet.