### PR TITLE
Update github actions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,7 +12,7 @@ jobs:
     name: Publish binary on Linux
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Build
       run: cd ckb-debugger && cargo build --release
     - name: Archive files
@@ -24,7 +24,7 @@ jobs:
     - name: Generate checksum
       run: cd dist && sha256sum ckb-debugger-linux-x64.tar.gz > ckb-debugger-linux-x64-sha256.txt
     - name: Upload
-      uses: softprops/action-gh-release@v1
+      uses: softprops/action-gh-release@v2
       with:
         files: |
           dist/ckb-debugger-linux-x64.tar.gz
@@ -34,7 +34,7 @@ jobs:
     name: Publish binary on macOS
     runs-on: macos-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Build
       run: cd ckb-debugger && cargo build --release
     - name: Archive files
@@ -46,7 +46,7 @@ jobs:
     - name: Generate checksum
       run: cd dist && shasum -a 256 ckb-debugger-macos-x64.tar.gz > ckb-debugger-macos-x64-sha256.txt
     - name: Upload
-      uses: softprops/action-gh-release@v1
+      uses: softprops/action-gh-release@v2
       with:
         files: |
           dist/ckb-debugger-macos-x64.tar.gz
@@ -56,7 +56,7 @@ jobs:
     name: Publish binary on Windows
     runs-on: windows-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Build
       run: cd ckb-debugger && cargo build --release
     - name: Archive files
@@ -68,7 +68,7 @@ jobs:
     - name: Generate checksum
       run: cd dist && Get-FileHash ckb-debugger-windows-x64.tar.gz > ckb-debugger-windows-x64-sha256.txt
     - name: Upload
-      uses: softprops/action-gh-release@v1
+      uses: softprops/action-gh-release@v2
       with:
         files: |
           dist/ckb-debugger-windows-x64.tar.gz
@@ -78,7 +78,7 @@ jobs:
     name: Publish crates to crates.io
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Publish
       run: |
         cargo login ${{ secrets.CARGO_REGISTRY_TOKEN }}

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -13,7 +13,7 @@ jobs:
   build-linux:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Build
       run: cargo build
     - name: Build ckb-vm-signal-profiler example
@@ -22,6 +22,6 @@ jobs:
   build-windows:
     runs-on: windows-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Build
       run: cd ckb-debugger && cargo build


### PR DESCRIPTION
<html>
<body>
<!--StartFragment-->
 
--
The following actions use a deprecated Node.js version and will be forced to run on node20: actions/checkout@v3, softprops/action-gh-release@v1. For more info: https://github.blog/changelog/2024-03-07-github-actions-all-actions-will-run-on-node20-instead-of-node16-by-default/Show less
 

<br class="Apple-interchange-newline"><!--EndFragment-->
</body>
</html>