### PR TITLE
Use a more friendly printer

### DIFF
--- a/ckb-debugger/src/main.rs
+++ b/ckb-debugger/src/main.rs
@@ -349,9 +349,9 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         )
     };
     verifier.set_debug_printer(Box::new(move |_hash: &Byte32, message: &str| {
-        print!("Script log: {}", message);
-        if !message.ends_with('\n') {
-            println!("");
+        let message = message.trim_end_matches('\n');
+        if message != "" {
+            println!("Script log: {}", message);
         }
     }));
     let verifier_script_group = verifier.find_script_group(verifier_script_group_type, &verifier_script_hash).unwrap();


### PR DESCRIPTION
Always print `\n`, but also avoid printing extra `\n`.