### PR TITLE
Update rust toolchain to v1.81.0

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "1.75.0"
+channel = "1.81.0"


### PR DESCRIPTION
Updated to be consistent with ckb <https://github.com/nervosnetwork/ckb/blob/develop/rust-toolchain.toml>