### PR TITLE
Fix macos release package name

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,15 +42,15 @@ jobs:
         mkdir dist
         cp target/release/ckb-debugger dist
         cp LICENSE dist
-        cd dist && tar -cvzf ckb-debugger-macos-x64.tar.gz ckb-debugger LICENSE
+        cd dist && tar -cvzf ckb-debugger-macos-arm64.tar.gz ckb-debugger LICENSE
     - name: Generate checksum
-      run: cd dist && shasum -a 256 ckb-debugger-macos-x64.tar.gz > ckb-debugger-macos-x64-sha256.txt
+      run: cd dist && shasum -a 256 ckb-debugger-macos-arm64.tar.gz > ckb-debugger-macos-arm64-sha256.txt
     - name: Upload
       uses: softprops/action-gh-release@v2
       with:
         files: |
-          dist/ckb-debugger-macos-x64.tar.gz
-          dist/ckb-debugger-macos-x64-sha256.txt
+          dist/ckb-debugger-macos-arm64.tar.gz
+          dist/ckb-debugger-macos-arm64-sha256.txt
 
   publish-windows:
     name: Publish binary on Windows


### PR DESCRIPTION
The `macos-latest` tag is now using macos for arm64 processors. See

https://docs.github.com/zh/actions/using-github-hosted-runners/using-github-hosted-runners/about-github-hosted-runners#%E7%94%A8%E4%BA%8E%E5%85%AC%E5%85%B1%E5%AD%98%E5%82%A8%E5%BA%93%E7%9A%84-github-%E6%89%98%E7%AE%A1%E7%9A%84%E6%A0%87%E5%87%86%E8%BF%90%E8%A1%8C%E5%99%A8