### PR TITLE
Add feature for using AsmMachine in debugger

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -19,6 +19,13 @@ jobs:
     - name: Build ckb-vm-signal-profiler example
       run: cargo build --examples --package ckb-vm-signal-profiler
 
+  build-linux-asm:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - name: Build
+      run: cargo build --features=asm
+
   build-windows:
     runs-on: windows-latest
     steps:

--- a/ckb-debugger/Cargo.toml
+++ b/ckb-debugger/Cargo.toml
@@ -8,6 +8,7 @@ edition = "2021"
 
 [features]
 default = []
+asm = ["ckb-script/asm"]
 
 [dependencies]
 addr2line = "0.17"

--- a/ckb-debugger/src/machine_analyzer.rs
+++ b/ckb-debugger/src/machine_analyzer.rs
@@ -5,7 +5,7 @@ use ckb_vm::decoder::{build_decoder, Decoder};
 use ckb_vm::instructions::instruction_length;
 use ckb_vm::machine::VERSION0;
 use ckb_vm::registers::{A0, SP};
-use ckb_vm::{Bytes, CoreMachine, Error, FlatMemory, Machine, Register, SupportMachine, WXorXMemory, ISA_MOP};
+use ckb_vm::{Bytes, CoreMachine, Error, Machine, Register, SupportMachine, ISA_MOP};
 use std::borrow::Cow;
 use std::cell::RefCell;
 use std::collections::HashMap;
@@ -424,7 +424,7 @@ where
     DL: CellDataProvider + HeaderProvider + ExtensionProvider + Send + Sync + Clone + 'static,
 {
     type REG = u64;
-    type MEM = WXorXMemory<FlatMemory<u64>>;
+    type MEM = <MachineAssign<DL> as CoreMachine>::MEM;
 
     fn pc(&self) -> &Self::REG {
         &self.machine.pc()

--- a/ckb-debugger/src/machine_assign.rs
+++ b/ckb-debugger/src/machine_assign.rs
@@ -1,12 +1,10 @@
-use ckb_script::{DataLocation, RunMode, Scheduler, VmArgs, ROOT_VM_ID};
+use ckb_script::{CoreMachine as CkbScriptCoreMachineType, DataLocation, RunMode, Scheduler, VmArgs, ROOT_VM_ID};
 use ckb_traits::{CellDataProvider, ExtensionProvider, HeaderProvider};
 use ckb_vm::cost_model::estimate_cycles;
 use ckb_vm::decoder::Decoder;
 use ckb_vm::instructions::execute;
 use ckb_vm::registers::A7;
-use ckb_vm::{
-    Bytes, CoreMachine, DefaultCoreMachine, Error, FlatMemory, Machine, SupportMachine, Syscalls, WXorXMemory,
-};
+use ckb_vm::{Bytes, CoreMachine, Error, Machine, SupportMachine, Syscalls};
 
 pub struct MachineAssign<DL>
 where
@@ -15,7 +13,7 @@ where
     pub id: u64,
     pub scheduler: Scheduler<DL>,
     pub expand_cycles: u64,
-    pub expand_syscalls: Vec<Box<(dyn Syscalls<DefaultCoreMachine<u64, WXorXMemory<FlatMemory<u64>>>>)>>,
+    pub expand_syscalls: Vec<Box<(dyn Syscalls<CkbScriptCoreMachineType>)>>,
 }
 
 impl<DL> CoreMachine for MachineAssign<DL>
@@ -23,7 +21,7 @@ where
     DL: CellDataProvider + HeaderProvider + ExtensionProvider + Send + Sync + Clone + 'static,
 {
     type REG = u64;
-    type MEM = WXorXMemory<FlatMemory<u64>>;
+    type MEM = <CkbScriptCoreMachineType as CoreMachine>::MEM;
 
     fn pc(&self) -> &Self::REG {
         let dm = &self.scheduler.instantiated.get(&self.id).unwrap().1.machine;

--- a/ckb-debugger/src/main.rs
+++ b/ckb-debugger/src/main.rs
@@ -487,7 +487,12 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                 })
                 .and_then(|inst| {
                     let regs = machine.registers().as_ptr();
+
+                    #[cfg(not(feature = "asm"))]
                     let memory = (&mut machine.memory_mut().inner_mut()).as_ptr();
+                    #[cfg(feature = "asm")]
+                    let memory = machine.memory().as_ref().memory.as_ptr();
+
                     let cycles = machine.cycles();
                     probe!(ckb_vm, execute_inst, pc, cycles, inst, regs, memory);
                     let r = execute(inst, &mut machine);


### PR DESCRIPTION
The consensus is now defined as the x64 assembly implementation of ckb-vm, having an alternative debugger binary that uses the assembly VM, can IMHO be helpful in certain cases. We all know the Rust version is easier to plug-in all kinds of utilities, but the assembly version will always have a handy place avoiding confusions.