### PR TITLE
Bump version to v0.200.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -334,7 +334,7 @@ dependencies = [
 
 [[package]]
 name = "ckb-debugger"
-version = "0.200.0"
+version = "0.200.1"
 dependencies = [
  "addr2line 0.17.0",
  "byteorder",
@@ -470,7 +470,7 @@ dependencies = [
 
 [[package]]
 name = "ckb-mock-tx-types"
-version = "0.200.0"
+version = "0.200.1"
 dependencies = [
  "ckb-jsonrpc-types",
  "ckb-traits",
@@ -632,7 +632,7 @@ dependencies = [
 
 [[package]]
 name = "ckb-vm-debug-utils"
-version = "0.200.0"
+version = "0.200.1"
 dependencies = [
  "byteorder",
  "bytes",
@@ -656,7 +656,7 @@ dependencies = [
 
 [[package]]
 name = "ckb-vm-pprof"
-version = "0.200.0"
+version = "0.200.1"
 dependencies = [
  "addr2line 0.17.0",
  "ckb-vm",
@@ -666,7 +666,7 @@ dependencies = [
 
 [[package]]
 name = "ckb-vm-pprof-converter"
-version = "0.200.0"
+version = "0.200.1"
 dependencies = [
  "ckb-vm-pprof-protos",
  "clap 4.5.16",
@@ -675,7 +675,7 @@ dependencies = [
 
 [[package]]
 name = "ckb-vm-pprof-protos"
-version = "0.200.0"
+version = "0.200.1"
 dependencies = [
  "protobuf",
  "protobuf-codegen",
@@ -684,7 +684,7 @@ dependencies = [
 
 [[package]]
 name = "ckb-vm-signal-profiler"
-version = "0.200.0"
+version = "0.200.1"
 dependencies = [
  "addr2line 0.17.0",
  "ckb-vm",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.200.0"
+version = "0.200.1"
 
 [workspace.dependencies]
 # CKB dependencies
@@ -24,13 +24,13 @@ ckb-types = "=0.200.0"
 ckb-vm = { version = "=0.24.13", default-features = false, features = ["pprof"] }
 
 # Crates defined in current workspace
-ckb-debugger = { path = "ckb-debugger", version = "0.200.0" }
-ckb-mock-tx-types = { path = "ckb-mock-tx-types", version = "0.200.0" }
-ckb-vm-debug-utils = { path = "ckb-vm-debug-utils", version = "0.200.0" }
-ckb-vm-pprof = { path = "ckb-vm-pprof", version = "0.200.0" }
-ckb-vm-pprof-converter = { path = "ckb-vm-pprof-converter", version = "0.200.0" }
-ckb-vm-pprof-protos = { path = "ckb-vm-pprof-protos", version = "0.200.0" }
-ckb-vm-signal-profiler = { path = "ckb-vm-signal-profiler", version = "0.200.0" }
+ckb-debugger = { path = "ckb-debugger", version = "0.200.1" }
+ckb-mock-tx-types = { path = "ckb-mock-tx-types", version = "0.200.1" }
+ckb-vm-debug-utils = { path = "ckb-vm-debug-utils", version = "0.200.1" }
+ckb-vm-pprof = { path = "ckb-vm-pprof", version = "0.200.1" }
+ckb-vm-pprof-converter = { path = "ckb-vm-pprof-converter", version = "0.200.1" }
+ckb-vm-pprof-protos = { path = "ckb-vm-pprof-protos", version = "0.200.1" }
+ckb-vm-signal-profiler = { path = "ckb-vm-signal-profiler", version = "0.200.1" }
 
 # Other common crates
 addr2line = "0.17"


### PR DESCRIPTION
This minor version mainly updates the rust edition to 2024, and makes the wasm work again.