### PR TITLE
Bump version to v1.1.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -235,9 +235,9 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
-version = "1.10.1"
+version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d71b6127be86fdcfddb610f7182ac57211d4b18a3e9c82eb2d17662f2227ad6a"
+checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 dependencies = [
  "serde",
 ]
@@ -292,9 +292,9 @@ checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "ckb-chain-spec"
-version = "1.0.0"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09a05c9a585f23869ad2394d006a42fb6746de499d91a2d5e302139ada37578d"
+checksum = "f3e8265b28af91d3b31015a21da9c596c061a4cb5e7dda18556a00273ed72b8a"
 dependencies = [
  "cacache",
  "ckb-constant",
@@ -348,7 +348,7 @@ dependencies = [
 
 [[package]]
 name = "ckb-debugger"
-version = "1.0.0"
+version = "1.1.0"
 dependencies = [
  "addr2line 0.21.0",
  "byteorder",
@@ -434,9 +434,9 @@ dependencies = [
 
 [[package]]
 name = "ckb-gen-types"
-version = "1.0.0"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e57ad8b6edc20d1614780e9034475e1edac24f3ef5edc197cbd6f0bc9b20eea6"
+checksum = "a5ca98134f68d56893330e64903ca478d41e2305bcb9cc5fe457934d3a081240"
 dependencies = [
  "cfg-if",
  "ckb-error",
@@ -451,9 +451,9 @@ dependencies = [
 
 [[package]]
 name = "ckb-hash"
-version = "1.0.0"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96bc608fd850b8f88fa07ed6fd432175eef4d83ab093c82bb6800333181993bb"
+checksum = "6038dc800eb3c8011df213e105a48c51f67e9904767af9356f0d3308b7afd618"
 dependencies = [
  "blake2b-ref",
  "blake2b-rs",
@@ -461,9 +461,9 @@ dependencies = [
 
 [[package]]
 name = "ckb-jsonrpc-types"
-version = "1.0.0"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93fd050ea71b67f1e4d304b3450c939a87a30dea5b27ba30c0231e2b75d51959"
+checksum = "e40fbcbc617d103c446391dac024f648645f04c13df5bd330e906a54e2de8546"
 dependencies = [
  "ckb-types",
  "ckb_schemars",
@@ -493,9 +493,9 @@ dependencies = [
 
 [[package]]
 name = "ckb-mock-tx-types"
-version = "1.0.0"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08f05c40c36a5109007a3721cdf940153a19bafade295407df0bad5113a524e4"
+checksum = "7ebfe8cb9be5d43a2ad2139e4b9757d9aaa4f9ffdddfc0c014894cbcc6c061ce"
 dependencies = [
  "ckb-jsonrpc-types",
  "ckb-traits",
@@ -574,9 +574,9 @@ dependencies = [
 
 [[package]]
 name = "ckb-script"
-version = "1.0.0"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8806961e94e46bca8c9f1612237fa49a479b43116627c25030b77e72cd3f0bed"
+checksum = "ab66949d545f03e7fff661ce68794fb60469d527476a3bf7f1133b6107dcbb69"
 dependencies = [
  "byteorder",
  "ckb-chain-spec",
@@ -593,9 +593,9 @@ dependencies = [
 
 [[package]]
 name = "ckb-std"
-version = "1.0.1"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8efe226c304a42f78ecdbea5924f7bd4654cbea69533896d6a4ab3d1916d1e03"
+checksum = "7defadecfc39d5a25cddf11d86308130d745262f8f006bd9f602e7c968596460"
 dependencies = [
  "buddy-alloc",
  "cc",
@@ -619,18 +619,18 @@ dependencies = [
 
 [[package]]
 name = "ckb-traits"
-version = "1.0.0"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d6f061d2788746ab9cd596fb9aa39d92ae3abce730c1792c2a2e064165c1ced"
+checksum = "02d0ea5b70843d04683740cf9078719d2d87d01004eb4ced11681006f600c976"
 dependencies = [
  "ckb-types",
 ]
 
 [[package]]
 name = "ckb-types"
-version = "1.0.0"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90a5f1e62fa0e969386928163607d22dd3563857ec134440ffe46a5ca68bb8fc"
+checksum = "bb1a584004fc6f2066a024b247e498305273cb37c14d34b23787977baefc018e"
 dependencies = [
  "bit-vec",
  "bytes",
@@ -670,7 +670,7 @@ dependencies = [
 
 [[package]]
 name = "ckb-vm-debug-utils"
-version = "1.0.0"
+version = "1.1.0"
 dependencies = [
  "byteorder",
  "bytes",
@@ -694,9 +694,9 @@ dependencies = [
 
 [[package]]
 name = "ckb-vm-fuzzing-utils"
-version = "1.0.0"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c70ccf64c4ce6f95b0df26bc2e22609505b20cd0d44ea2837dae1fd851aa408"
+checksum = "9461c1ca9d371beb8726823bbc07a7f4232208fd27547e6c1cf3893b40ff50f3"
 dependencies = [
  "ckb-std",
  "ckb-vm",
@@ -706,7 +706,7 @@ dependencies = [
 
 [[package]]
 name = "ckb-vm-pprof"
-version = "1.0.0"
+version = "1.1.0"
 dependencies = [
  "addr2line 0.21.0",
  "ckb-vm",
@@ -716,7 +716,7 @@ dependencies = [
 
 [[package]]
 name = "ckb-vm-pprof-converter"
-version = "1.0.0"
+version = "1.1.0"
 dependencies = [
  "ckb-vm-pprof-protos",
  "clap 4.5.42",
@@ -725,7 +725,7 @@ dependencies = [
 
 [[package]]
 name = "ckb-vm-pprof-protos"
-version = "1.0.0"
+version = "1.1.0"
 dependencies = [
  "protobuf",
  "protobuf-codegen",
@@ -734,7 +734,7 @@ dependencies = [
 
 [[package]]
 name = "ckb-vm-signal-profiler"
-version = "1.0.0"
+version = "1.1.0"
 dependencies = [
  "addr2line 0.21.0",
  "ckb-vm",
@@ -747,9 +747,9 @@ dependencies = [
 
 [[package]]
 name = "ckb-vm-syscall-tracer"
-version = "1.0.0"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19dcb8e4adb1003315e8181117a29b3d93e4f9144234d2950dc9af7368591992"
+checksum = "478fee567f7f7b41f43b428b9a839508c919111e31d81f4909ef9d65984e3d5f"
 dependencies = [
  "ckb-chain-spec",
  "ckb-mock-tx-types",
@@ -1537,9 +1537,9 @@ dependencies = [
 
 [[package]]
 name = "molecule"
-version = "0.8.0"
+version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6efe1c7efcd0bdf4ca590e104bcb13087d9968956ae4ae98e92fb8c1da0f3730"
+checksum = "314eebe1fb025f681c1d6a62fdacbe831027177c1046503a8d73d8027fe19e16"
 dependencies = [
  "bytes",
  "cfg-if",
@@ -1920,9 +1920,9 @@ dependencies = [
 
 [[package]]
 name = "protobuf-ckb-syscalls"
-version = "1.0.0"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "944f494b54e4edbe1021bef90e621d59fa72171f299800b53090dccfddd6814a"
+checksum = "eabda389874de523c9d2e97adee84d956c4e86926df4347656d64e1ad8ac8bb9"
 dependencies = [
  "ckb-std",
  "ckb-vm",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,31 +10,31 @@ members = [
 ]
 
 [workspace.package]
-version = "1.0.0"
+version = "1.1.0"
 
 [workspace.dependencies]
 # CKB dependencies
-ckb-chain-spec = "=1.0.0"
-ckb-hash = "=1.0.0"
-ckb-jsonrpc-types = "=1.0.0"
-ckb-script = { version = "=1.0.0", default-features = false, features = ["flatmemory"] }
-ckb-traits = "=1.0.0"
-ckb-types = "=1.0.0"
+ckb-chain-spec = "=1.1.0"
+ckb-hash = "=1.1.0"
+ckb-jsonrpc-types = "=1.1.0"
+ckb-script = { version = "=1.1.0", default-features = false, features = ["flatmemory"] }
+ckb-traits = "=1.1.0"
+ckb-types = "=1.1.0"
 ckb-vm = { version = "=0.24.14", default-features = false, features = ["pprof"] }
 
 # Crates defined in current workspace
-ckb-debugger = { path = "ckb-debugger", version = "1.0.0" }
-ckb-vm-debug-utils = { path = "ckb-vm-debug-utils", version = "1.0.0" }
-ckb-vm-pprof = { path = "ckb-vm-pprof", version = "1.0.0" }
-ckb-vm-pprof-converter = { path = "ckb-vm-pprof-converter", version = "1.0.0" }
-ckb-vm-pprof-protos = { path = "ckb-vm-pprof-protos", version = "1.0.0" }
-ckb-vm-signal-profiler = { path = "ckb-vm-signal-profiler", version = "1.0.0" }
+ckb-debugger = { path = "ckb-debugger", version = "1.1.0" }
+ckb-vm-debug-utils = { path = "ckb-vm-debug-utils", version = "1.1.0" }
+ckb-vm-pprof = { path = "ckb-vm-pprof", version = "1.1.0" }
+ckb-vm-pprof-converter = { path = "ckb-vm-pprof-converter", version = "1.1.0" }
+ckb-vm-pprof-protos = { path = "ckb-vm-pprof-protos", version = "1.1.0" }
+ckb-vm-signal-profiler = { path = "ckb-vm-signal-profiler", version = "1.1.0" }
 
 # CKB VM contribs
-ckb-mock-tx-types = "1.0.0"
-ckb-vm-syscall-tracer = { version = "1.0.0", default-features = false }
-ckb-vm-fuzzing-utils = "1.0.0"
-protobuf-ckb-syscalls = "1.0.0"
+ckb-mock-tx-types = "1.1.0"
+ckb-vm-syscall-tracer = { version = "1.1.0", default-features = false }
+ckb-vm-fuzzing-utils = "1.1.0"
+protobuf-ckb-syscalls = "1.1.0"
 
 # Other common crates
 addr2line = "0.21"

--- a/README.md
+++ b/README.md
@@ -11,8 +11,11 @@ CKB standalone debugger is a collection of debugging tools.
 
 We provide a command line tool that allows you to develop CKB scripts offline. To install
 
+1. Download binarys from [Releases page](https://github.com/nervosnetwork/ckb-standalone-debugger/releases)
+2. Or install from source code using cargo:
+
 ```sh
-cargo install --git https://github.com/nervosnetwork/ckb-standalone-debugger ckb-debugger
+$ cargo install --locked --git https://github.com/nervosnetwork/ckb-standalone-debugger ckb-debugger
 ```
 
 And then refer to the sample programs we provided [examples](./ckb-debugger/examples/)

--- a/ckb-debugger/src/main.rs
+++ b/ckb-debugger/src/main.rs
@@ -418,7 +418,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                                  sg_data: &SgData<Resource>,
                                  vm_context: &VmContext<Resource>,
                                  vm_v: &Vec<Option<&str>>|
-         -> Vec<Box<(dyn Syscalls<<Machine as DefaultMachineRunner>::Inner>)>> {
+         -> Vec<Box<dyn Syscalls<<Machine as DefaultMachineRunner>::Inner>>> {
             let debug_printer: DebugPrinter = Arc::new(|_: &Byte32, message: &str| {
                 let message = message.trim_end_matches('\n');
                 if message != "" {
@@ -702,7 +702,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                 let mut machine = machine_init();
                 machine.set_running(true);
                 let mut h = GdbStubHandler::new(machine);
-                let connection: Box<(dyn ConnectionExt<Error = std::io::Error> + 'static)> = Box::new(stream);
+                let connection: Box<dyn ConnectionExt<Error = std::io::Error> + 'static> = Box::new(stream);
                 let gdb = GdbStub::new(connection);
 
                 let result = match gdb.run_blocking::<GdbStubHandlerEventLoop<_, Riscv64>>(&mut h) {

--- a/ckb-vm-debug-utils/examples/gdb_remote_protocol_debugger.rs
+++ b/ckb-vm-debug-utils/examples/gdb_remote_protocol_debugger.rs
@@ -2,22 +2,24 @@
 extern crate log;
 
 use bytes::Bytes;
-use ckb_gdb_remote_protocol::process_packets_from;
 use ckb_vm::machine::VERSION2;
 use ckb_vm::{
     DefaultCoreMachine, DefaultMachineBuilder, ISA_A, ISA_B, ISA_IMC, ISA_MOP, SparseMemory, SupportMachine,
     WXorXMemory,
 };
-use ckb_vm_debug_utils::GdbHandler;
 #[cfg(feature = "stdio")]
 use ckb_vm_debug_utils::Stdio;
+use ckb_vm_debug_utils::{GdbStubHandler, GdbStubHandlerEventLoop};
+use gdbstub::conn::ConnectionExt;
+use gdbstub::stub::{DisconnectReason, GdbStub};
+use gdbstub_arch::riscv::Riscv64;
 use std::env;
 use std::fs::File;
 use std::io::Read;
 use std::net::TcpListener;
 
 fn main() {
-    drop(env_logger::init());
+    let _ = env_logger::init();
     let args: Vec<String> = env::args().skip(1).collect();
 
     let listener = TcpListener::bind(&args[0]).expect("listen");
@@ -43,10 +45,26 @@ fn main() {
             let mut machine = machine_builder.syscall(Box::new(Stdio::new(true))).build();
             #[cfg(not(feature = "stdio"))]
             let mut machine = machine_builder.build();
-            machine.load_program(&program, &program_args).expect("load program");
+            machine.load_program(&program, program_args.iter().cloned().map(Ok)).expect("load program");
             machine.set_running(true);
-            let h = GdbHandler::new(machine);
-            process_packets_from(stream.try_clone().unwrap(), stream, h);
+            let mut h = GdbStubHandler::<_, Riscv64>::new(machine);
+            let connection: Box<dyn ConnectionExt<Error = std::io::Error>> = Box::new(stream);
+            let gdb = GdbStub::new(connection);
+            match gdb.run_blocking::<GdbStubHandlerEventLoop<_, Riscv64>>(&mut h) {
+                Ok(DisconnectReason::Disconnect) => {
+                    debug!("GDB client disconnected, running to completion");
+                    let _ = h.run_till_exited();
+                }
+                Ok(DisconnectReason::TargetExited(_)) => {
+                    let _ = h.run_till_exited();
+                }
+                Ok(reason) => {
+                    debug!("GDB session ended: {:?}", reason);
+                }
+                Err(e) => {
+                    debug!("GDB stub error: {}", e);
+                }
+            }
         }
         debug!("Connection closed");
     }

--- a/ckb-vm-debug-utils/examples/gdbstub_debugger.rs
+++ b/ckb-vm-debug-utils/examples/gdbstub_debugger.rs
@@ -16,7 +16,7 @@ use std::io::Read;
 use std::net::TcpListener;
 
 fn main() {
-    drop(env_logger::init());
+    let _ = env_logger::init();
     let args: Vec<String> = env::args().skip(1).collect();
 
     let listener = TcpListener::bind(&args[0]).expect("listen");
@@ -42,7 +42,7 @@ fn main() {
             let mut machine = machine_builder.syscall(Box::new(Stdio::new(true))).build();
             #[cfg(not(feature = "stdio"))]
             let mut machine = machine_builder.build();
-            machine.load_program(&program, &program_args).expect("load program");
+            machine.load_program(&program, program_args.iter().cloned().map(Ok)).expect("load program");
             machine.set_running(true);
             let mut h: GdbStubHandler<_, Riscv64> = GdbStubHandler::new(machine);
             let connection: Box<(dyn ConnectionExt<Error = std::io::Error> + 'static)> = Box::new(stream);

--- a/ckb-vm-debug-utils/src/gdbstub.rs
+++ b/ckb-vm-debug-utils/src/gdbstub.rs
@@ -229,7 +229,7 @@ impl<
     type Arch = A;
     type Error = Error;
 
-    fn base_ops(&mut self) -> BaseOps<Self::Arch, Self::Error> {
+    fn base_ops(&mut self) -> BaseOps<'_, Self::Arch, Self::Error> {
         BaseOps::SingleThread(self)
     }
 

--- a/ckb-vm-pprof/src/lib.rs
+++ b/ckb-vm-pprof/src/lib.rs
@@ -395,7 +395,7 @@ impl<R: Register, M: Memory<REG = R>, Inner: SupportMachine<REG = R, MEM = M>> P
 }
 
 pub fn quick_start(
-    syscalls: Vec<Box<(dyn Syscalls<DefaultCoreMachine<u64, WXorXMemory<SparseMemory<u64>>>>)>>,
+    syscalls: Vec<Box<dyn Syscalls<DefaultCoreMachine<u64, WXorXMemory<SparseMemory<u64>>>>>>,
     fl_bin: &str,
     fl_arg: Vec<&str>,
     output_filename: &str,

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "1.85.0"
+channel = "1.92.0"


### PR DESCRIPTION
We now recommend that users directly download our pre-compiled binary.